### PR TITLE
Remove named capture groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: R
 sudo: false
 latex: false
 cache: packages
-dist: xenial
 
 matrix:
   include:

--- a/R/translate.R
+++ b/R/translate.R
@@ -115,9 +115,9 @@ replace_math <- function(x) {
   #   2. <p>%2%D%O%L%L%A%R%...%2%D%O%L%L%A%R%</p>
   x <- stringi::stri_replace_all_regex(
     x,
-    '(^|(?<=<p>))\\s*%2%D%O%L%L%A%R%(?<content>.*?)%2%D%O%L%L%A%R%\\s*($|(?=</p>))',
+    '(^|(?<=<p>))\\s*%2%D%O%L%L%A%R%(.*?)%2%D%O%L%L%A%R%\\s*($|(?=</p>))',
 '<ac:structured-macro ac:name="mathblock">
-  <ac:plain-text-body><![CDATA[${content}]]></ac:plain-text-body>
+  <ac:plain-text-body><![CDATA[$2]]></ac:plain-text-body>
 </ac:structured-macro>',
     multiline = TRUE,
     dotall = TRUE


### PR DESCRIPTION
Fix #1 

[Named capture groups](http://site.icu-project.org/design/regular-expressions/named-capture-groups) feature is available only after ICU 55, but this newer ICU is not always available. So, it seems better to remove them at least for now.