### PR TITLE
Use askpass to enable to ask URL, username, and password outside RStudio

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Imports:
+    askpass,
     commonmark,
     curl,
     glue,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Added a `NEWS.md` file to track changes to the package.
 
+* conflr now works outside RStudio (e.g. Emacs/Vim) thanks to the power of
+  askpass package (#10).
+
 # conflr 0.0.5
 
 * Initial release on GitHub

--- a/R/util.R
+++ b/R/util.R
@@ -18,9 +18,30 @@
   if (is.null(lhs) || identical(lhs, "")) rhs else lhs
 }
 
-ask_confluence_url <- function() rstudioapi::showPrompt("URL", "Base URL of Confluence API: ", default = "https://")
-ask_confluence_username <- function() rstudioapi::showPrompt("Username", "Username for Confluence: ", default = "")
-ask_confluence_password <- function() rstudioapi::askForPassword("Password for Confluence: ")
+ask_secret <- function(message) {
+  if (!interactive()) {
+    stop("Please set up environmental variables before running non-interactive session.", call. = FALSE)
+  }
+
+  askpass::askpass(message)
+}
+
+ask_non_secret <- function(title, message, default = NULL) {
+  if (!interactive()) {
+    stop("Please set up environmental variables before running non-interactive session.", call. = FALSE)
+  }
+
+  if (rstudioapi::isAvailable()) {
+    return(rstudioapi::showPrompt(title, message, default))
+  }
+
+  # Fallback to the readline
+  readline(message)
+}
+
+ask_confluence_url <- function() ask_non_secret("URL", "Base URL of Confluence API: ", default = "https://")
+ask_confluence_username <- function() ask_non_secret("Username", "Username for Confluence: ", default = "")
+ask_confluence_password <- function() ask_secret("Password for Confluence: ")
 
 confl_verb <- function(verb, path, ...) {
   base_url <- Sys.getenv("CONFLUENCE_URL") %|""|% ask_confluence_url()


### PR DESCRIPTION
(Related to #10)

Currently, conflr uses `rstudioapi::showPrompt()` and `rstudioapi::askForPassword()`. But, these are not available outside RStudio. This PR changes the method to askpass package, which works well in many cases. askpass package is licensed under MIT, so adding this doesn't conflict with the current packages.

c.f. https://github.com/jeroen/askpass

Note that, conflr stilll uses `showPrompt()` if possible, since it's slightly more convenient in that we can set the default value on it.