### PR TITLE
Add an option to control the default size of the image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * conflr now works outside RStudio (e.g. Emacs/Vim) thanks to the power of
   askpass package (#10).
+  
+* Addin now has "Use original image sizes" option to control whether to resize
+  the image (default) or not (#21).
 
 # conflr 0.0.5
 

--- a/R/addin.R
+++ b/R/addin.R
@@ -86,7 +86,7 @@ confl_addin_upload <- function(md_file, title, tags) {
         shiny::column(
           width = 2,
           shiny::selectInput(
-            inputId = "type", label = "type",
+            inputId = "type", label = "Type",
             choices = eval(formals(confl_post_page)$type),
           )
         ),
@@ -102,6 +102,13 @@ confl_addin_upload <- function(md_file, title, tags) {
           shiny::textInput(
             inputId = "ancestors", label = "Parent page ID",
             value = NULL
+          )
+        ),
+        shiny::column(
+          width = 4,
+          shiny::checkboxInput(
+            inputId = "use_original_size", label = "Use the original image size",
+            value = FALSE
           )
         )
       ),
@@ -175,10 +182,12 @@ confl_addin_upload <- function(md_file, title, tags) {
       # Step 2) Upload the document
       progress$set(message = "Uploading the document...")
 
+      image_size_default <- if (!input$use_original_size) 600 else NULL
       result <- confl_update_page(
         id = id,
         title = title,
-        body = html_text
+        body = html_text,
+        image_size_default = image_size_default
       )
 
       progress$set(value = 2, message = "Done!")

--- a/R/addin.R
+++ b/R/addin.R
@@ -107,7 +107,7 @@ confl_addin_upload <- function(md_file, title, tags) {
         shiny::column(
           width = 4,
           shiny::checkboxInput(
-            inputId = "use_original_size", label = "Use the original image size",
+            inputId = "use_original_size", label = "Use original image sizes",
             value = FALSE
           )
         )

--- a/R/content.R
+++ b/R/content.R
@@ -58,15 +58,18 @@ confl_get_page <- function(id, expand = "body.storage") {
 #'   The HTML source of the page.
 #' @param ancestors
 #'   The page ID of the parent pages.
+#' @param image_size_default
+#'   The default width of images in pixel. If `NULL`, images are displayed in their original sizes.
 #' @export
 confl_post_page <- function(type = c("page", "blogpost"),
                             spaceKey,
                             title,
                             body,
-                            ancestors = NULL) {
+                            ancestors = NULL,
+                            image_size_default = 600) {
   type <- match.arg(type)
 
-  body <- translate_to_confl_macro(body)
+  body <- translate_to_confl_macro(body, image_size_default = image_size_default)
 
   req_body = list(
     type = type,
@@ -88,11 +91,12 @@ confl_post_page <- function(type = c("page", "blogpost"),
 #' @export
 confl_update_page <- function(id,
                               title,
-                              body) {
+                              body,
+                              image_size_default = 600) {
   id <- as.character(id)
   page_info <- confl_get_page(id, expand = "version")
 
-  body <- translate_to_confl_macro(body)
+  body <- translate_to_confl_macro(body, image_size_default = image_size_default)
 
   res <- confl_verb("PUT", glue::glue("/content/{id}"),
                     body = list(

--- a/man/confl_content.Rd
+++ b/man/confl_content.Rd
@@ -16,9 +16,9 @@ confl_list_pages(type = c("page", "blogpost", "comment", "attachment"),
 confl_get_page(id, expand = "body.storage")
 
 confl_post_page(type = c("page", "blogpost"), spaceKey, title, body,
-  ancestors = NULL)
+  ancestors = NULL, image_size_default = 600)
 
-confl_update_page(id, title, body)
+confl_update_page(id, title, body, image_size_default = 600)
 
 confl_delete_page(id)
 }
@@ -41,6 +41,8 @@ contents, use periods. (e.g. \code{body.storage,history}).}
 \item{body}{The HTML source of the page.}
 
 \item{ancestors}{The page ID of the parent pages.}
+
+\item{image_size_default}{The default width of images in pixel. If \code{NULL}, images are displayed in their original sizes.}
 }
 \description{
 REST Wrapper for the ContentService

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -101,24 +101,42 @@ $$")
 test_that("replace_image() works", {
   expect_equal(
     replace_image('<img src="/path/to/img.png" alt="foo"/>'),
-    '<ac:image ac:height="400"><ri:attachment ri:filename="img.png" /></ac:image>'
+    '<ac:image ac:width="600"><ri:attachment ri:filename="img.png" /></ac:image>'
   )
 
   expect_equal(
     replace_image('<img src="/path/to/img.png" />'),
-    '<ac:image ac:height="400"><ri:attachment ri:filename="img.png" /></ac:image>'
+    '<ac:image ac:width="600"><ri:attachment ri:filename="img.png" /></ac:image>'
   )
 
   # use width
   expect_equal(
     replace_image('<img src="/path/to/img.png" height="300" />'),
-    '<ac:image ac:height="300"><ri:attachment ri:filename="img.png" /></ac:image>'
+    '<ac:image ac:width="600" ac:height="300"><ri:attachment ri:filename="img.png" /></ac:image>'
   )
 
   # use width and height
   expect_equal(
     replace_image('<img src="/path/to/img.png" height="300" width="300" />'),
-    '<ac:image ac:height="300" ac:width="300"><ri:attachment ri:filename="img.png" /></ac:image>'
+    '<ac:image ac:width="300" ac:height="300"><ri:attachment ri:filename="img.png" /></ac:image>'
+  )
+
+  # use the other default size
+  expect_equal(
+    replace_image('<img src="/path/to/img.png" />', image_size_default = 333),
+    '<ac:image ac:width="333"><ri:attachment ri:filename="img.png" /></ac:image>'
+  )
+  
+  # the default size is ignored when the image has its width
+  expect_equal(
+    replace_image('<img src="/path/to/img.png" width="450" />', image_size_default = 333),
+    '<ac:image ac:width="450"><ri:attachment ri:filename="img.png" /></ac:image>'
+  )
+
+  # use the original size
+  expect_equal(
+    replace_image('<img src="/path/to/img.png" />', image_size_default = NULL),
+    '<ac:image ><ri:attachment ri:filename="img.png" /></ac:image>'
   )
 })
 
@@ -158,7 +176,7 @@ iris$Species
   html_text <- commonmark::markdown_html("![foo](/path/to/foo.png)")
   expect_equal(
     translate_to_confl_macro(html_text),
-    '<p>\n  <ac:image ac:height="400"><ri:attachment ri:filename="foo.png" /></ac:image>\n</p>'
+    '<p>\n  <ac:image ac:width="600"><ri:attachment ri:filename="foo.png" /></ac:image>\n</p>'
   )
   # inline math
   html_text <- commonmark::markdown_html("$ is $\\frac{1}{3}$")


### PR DESCRIPTION
Fix #21 

## Internal

Currently, conflr sets the *height* to 400 on all images that don't have *height* attribute; if an image has its own heights and width, those are respected by the change of #7.

This PR changes to set *width* to 600 on on all images that don't have *width* attribute. Probably, this changes the visual appearance, but setting width is in line with what the Confluence's editor does.

<img width="280" alt="スクリーンショット 2019-03-14 10 32 42" src="https://user-images.githubusercontent.com/1978793/54325247-926f5100-4644-11e9-9138-1c3bdfcb82e5.png">

## User visible changes

This PR adds a new argument `image_size_default` to `confl_post_page()` and `confl_update_page()`. When this is `NULL`, no `width` or `height` will be set, which means the images will be displayed as the original sizes.

But the parameter is not directly exposed to the addin. Instead, a simple checkbox is added for simplicity. If this is checked, `image_size_default = NULL` is used.

<img width="690" alt="スクリーンショット 2019-03-14 10 37 26" src="https://user-images.githubusercontent.com/1978793/54325377-2fca8500-4645-11e9-8cce-feb690468c18.png">

## TODO

* Update README in another PR