### PR TITLE
Add an option to control whether to notify watchers or not

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,11 @@
 * conflr now works outside RStudio (e.g. Emacs/Vim) thanks to the power of
   askpass package (#10).
 
-* Addin now has "Use original image sizes" option to control whether to resize
+* conflr addin now has "Use original image sizes" option to control whether to resize
   the image (default) or not (#21).
+
+* conflr addin now has "Notify watchers" option to control whether to notify watchers
+  (default) or not (#20).
 
 # conflr 0.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * conflr now works outside RStudio (e.g. Emacs/Vim) thanks to the power of
   askpass package (#10).
-  
+
 * Addin now has "Use original image sizes" option to control whether to resize
   the image (default) or not (#21).
 

--- a/R/addin.R
+++ b/R/addin.R
@@ -109,6 +109,10 @@ confl_addin_upload <- function(md_file, title, tags) {
           shiny::checkboxInput(
             inputId = "use_original_size", label = "Use original image sizes",
             value = FALSE
+          ),
+          shiny::checkboxInput(
+            inputId = "notify_watchers", label = "Notify watchers",
+            value = TRUE
           )
         )
       ),
@@ -187,6 +191,7 @@ confl_addin_upload <- function(md_file, title, tags) {
         id = id,
         title = title,
         body = html_text,
+        minor_edit = !input$notify_watchers,
         image_size_default = image_size_default
       )
 

--- a/R/content.R
+++ b/R/content.R
@@ -88,10 +88,13 @@ confl_post_page <- function(type = c("page", "blogpost"),
 }
 
 #' @rdname confl_content
+#' @param minor_edit
+#'   If `FALSE`, do not notify to the watchers.
 #' @export
 confl_update_page <- function(id,
                               title,
                               body,
+                              minor_edit = FALSE,
                               image_size_default = 600) {
   id <- as.character(id)
   page_info <- confl_get_page(id, expand = "version")
@@ -103,7 +106,10 @@ confl_update_page <- function(id,
                       type = page_info$type,
                       title = title,
                       body = list(storage = list(value = body, representation = "storage")),
-                      version = list(number = page_info$version$number + 1L)
+                      version = list(
+                        number = page_info$version$number + 1L,
+                        minorEdit = minor_edit
+                      )
                     ),
                     encode = "json")
   httr::content(res)

--- a/R/content.R
+++ b/R/content.R
@@ -89,7 +89,7 @@ confl_post_page <- function(type = c("page", "blogpost"),
 
 #' @rdname confl_content
 #' @param minor_edit
-#'   If `FALSE`, do not notify to the watchers.
+#'   If `FALSE`, do not notify the watchers.
 #' @export
 confl_update_page <- function(id,
                               title,

--- a/man/confl_content.Rd
+++ b/man/confl_content.Rd
@@ -45,7 +45,7 @@ contents, use periods. (e.g. \code{body.storage,history}).}
 
 \item{image_size_default}{The default width of images in pixel. If \code{NULL}, images are displayed in their original sizes.}
 
-\item{minor_edit}{If \code{FALSE}, do not notify to the watchers.}
+\item{minor_edit}{If \code{FALSE}, do not notify the watchers.}
 }
 \description{
 REST Wrapper for the ContentService

--- a/man/confl_content.Rd
+++ b/man/confl_content.Rd
@@ -18,7 +18,8 @@ confl_get_page(id, expand = "body.storage")
 confl_post_page(type = c("page", "blogpost"), spaceKey, title, body,
   ancestors = NULL, image_size_default = 600)
 
-confl_update_page(id, title, body, image_size_default = 600)
+confl_update_page(id, title, body, minor_edit = FALSE,
+  image_size_default = 600)
 
 confl_delete_page(id)
 }
@@ -43,6 +44,8 @@ contents, use periods. (e.g. \code{body.storage,history}).}
 \item{ancestors}{The page ID of the parent pages.}
 
 \item{image_size_default}{The default width of images in pixel. If \code{NULL}, images are displayed in their original sizes.}
+
+\item{minor_edit}{If \code{FALSE}, do not notify to the watchers.}
 }
 \description{
 REST Wrapper for the ContentService

--- a/tests/testthat/test-content.R
+++ b/tests/testthat/test-content.R
@@ -36,9 +36,9 @@ test_that("confl_update_page() works", {
   skip_on_ci_or_cran()
 
   res <- structure(list(status_code = 200), class = "response")
-  m <- mockery::mock(res)
+  m <- mockery::mock(res, cycle = TRUE)
   info <- list(version = list(number = 11L), type = "page")
-  m2 <- mockery::mock(info)
+  m2 <- mockery::mock(info, cycle = TRUE)
 
   with_mock(
     "conflr::confl_verb" = m,
@@ -46,9 +46,10 @@ test_that("confl_update_page() works", {
     "httr::content" = function(res) NULL,
     {
       confl_update_page("1234", "title", "<p>foo</p>")
+      confl_update_page("1234", "title", "<p>foo</p>", minor_edit = TRUE)
     }
   )
-    args <- mockery::mock_args(m)[[1]]
+  args <- mockery::mock_args(m)[[1]]
   expect_equal(args$body, list(
     type = "page",
     title = "title",
@@ -59,7 +60,24 @@ test_that("confl_update_page() works", {
       )
     ),
     version = list(
-      number = 12L
+      number = 12L,
+      minorEdit = FALSE
+    )
+  ))
+
+  args <- mockery::mock_args(m)[[2]]
+  expect_equal(args$body, list(
+    type = "page",
+    title = "title",
+    body =  list(
+      storage = list(
+        value = "<p>foo</p>",
+        representation = "storage"
+      )
+    ),
+    version = list(
+      number = 12L,
+      minorEdit = TRUE
     )
   ))
 })


### PR DESCRIPTION
Fix #20 

Add `minor_edit` option to `confl_update_page()`. For addin, "Notify watchers" (the same label as the Confluence's editor) option is added.

<img width="650" alt="スクリーンショット 2019-03-14 11 24 19" src="https://user-images.githubusercontent.com/1978793/54326959-bb471480-464b-11e9-8391-def17b6c9434.png">


