### PR TITLE
Revert #23

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -109,10 +109,6 @@ confl_addin_upload <- function(md_file, title, tags) {
           shiny::checkboxInput(
             inputId = "use_original_size", label = "Use original image sizes",
             value = FALSE
-          ),
-          shiny::checkboxInput(
-            inputId = "notify_watchers", label = "Notify watchers",
-            value = TRUE
           )
         )
       ),
@@ -191,7 +187,6 @@ confl_addin_upload <- function(md_file, title, tags) {
         id = id,
         title = title,
         body = html_text,
-        minor_edit = !input$notify_watchers,
         image_size_default = image_size_default
       )
 

--- a/R/content.R
+++ b/R/content.R
@@ -89,13 +89,10 @@ confl_post_page <- function(type = c("page", "blogpost"),
 }
 
 #' @rdname confl_content
-#' @param minor_edit
-#'   If `FALSE`, do not notify the watchers.
 #' @export
 confl_update_page <- function(id,
                               title,
                               body,
-                              minor_edit = FALSE,
                               image_size_default = 600) {
   id <- as.character(id)
   page_info <- confl_get_page(id, expand = "version")
@@ -108,8 +105,7 @@ confl_update_page <- function(id,
       title = title,
       body = list(storage = list(value = body, representation = "storage")),
       version = list(
-        number = page_info$version$number + 1L,
-        minorEdit = minor_edit
+        number = page_info$version$number + 1L
       )
     ),
     encode = "json"

--- a/man/confl_content.Rd
+++ b/man/confl_content.Rd
@@ -18,8 +18,7 @@ confl_get_page(id, expand = "body.storage")
 confl_post_page(type = c("page", "blogpost"), spaceKey, title, body,
   ancestors = NULL, image_size_default = 600)
 
-confl_update_page(id, title, body, minor_edit = FALSE,
-  image_size_default = 600)
+confl_update_page(id, title, body, image_size_default = 600)
 
 confl_delete_page(id)
 }
@@ -44,8 +43,6 @@ contents, use periods. (e.g. \code{body.storage,history}).}
 \item{ancestors}{The page ID of the parent pages.}
 
 \item{image_size_default}{The default width of images in pixel. If \code{NULL}, images are displayed in their original sizes.}
-
-\item{minor_edit}{If \code{FALSE}, do not notify the watchers.}
 }
 \description{
 REST Wrapper for the ContentService

--- a/tests/testthat/test-content.R
+++ b/tests/testthat/test-content.R
@@ -35,16 +35,15 @@ test_that("confl_update_page() works", {
   skip_on_ci_or_cran()
 
   res <- structure(list(status_code = 200), class = "response")
-  m <- mockery::mock(res, cycle = TRUE)
+  m <- mockery::mock(res)
   info <- list(version = list(number = 11L), type = "page")
-  m2 <- mockery::mock(info, cycle = TRUE)
+  m2 <- mockery::mock(info)
 
   with_mock(
     "conflr::confl_verb" = m,
     "conflr::confl_get_page" = m2,
     "httr::content" = function(res) NULL, {
       confl_update_page("1234", "title", "<p>foo</p>")
-      confl_update_page("1234", "title", "<p>foo</p>", minor_edit = TRUE)
     }
   )
   args <- mockery::mock_args(m)[[1]]
@@ -58,24 +57,7 @@ test_that("confl_update_page() works", {
       )
     ),
     version = list(
-      number = 12L,
-      minorEdit = FALSE
-    )
-  ))
-
-  args <- mockery::mock_args(m)[[2]]
-  expect_equal(args$body, list(
-    type = "page",
-    title = "title",
-    body = list(
-      storage = list(
-        value = "<p>foo</p>",
-        representation = "storage"
-      )
-    ),
-    version = list(
-      number = 12L,
-      minorEdit = TRUE
+      number = 12L
     )
   ))
 })


### PR DESCRIPTION
`minorEdit` option doesn't seem to work. Revert for now to avoid confusion.

See #20 for the details.