### PR TITLE
Console Upload

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -15,7 +15,8 @@
 #'
 #' @param Rmd_file path to a .Rmd file. If `NULL`, use the active document.
 #' @param interactive If `FALSE` shiny interface is not launched.
-#' @param ... Addtional arguments passed to [confl_console_upload()].
+#' @param title If provided this overwrites the YAML front matter title.
+#' @param ... Addtional arguments passed to `confl_console_upload()`.
 #'
 #' @export
 confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = interactive(),

--- a/R/addin.R
+++ b/R/addin.R
@@ -14,9 +14,11 @@
 #' Knit and post a given R Markdown file to 'Confluence'.
 #'
 #' @param Rmd_file path to a .Rmd file. If `NULL`, use the active document.
+#' @param interactive If `FALSE` shiny interface is not launched.
+#' @param ... Addtional arguments passed to [confl_console_upload()].
 #'
 #' @export
-confl_create_post_from_Rmd <- function(Rmd_file = NULL, shiny = TRUE,
+confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = interactive(),
                                        title = NULL, ...) {
   if (is.null(Rmd_file) && rstudioapi::isAvailable()) {
     Rmd_file <- rstudioapi::getSourceEditorContext()$path
@@ -61,7 +63,7 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, shiny = TRUE,
     front_matter$title <- title
   }
 
-  if (shiny) {
+  if (interactive) {
     confl_addin_upload(
       md_file = md_file,
       title = front_matter$title,

--- a/R/addin.R
+++ b/R/addin.R
@@ -16,7 +16,8 @@
 #' @param Rmd_file path to a .Rmd file. If `NULL`, use the active document.
 #'
 #' @export
-confl_create_post_from_Rmd <- function(Rmd_file = NULL) {
+confl_create_post_from_Rmd <- function(Rmd_file = NULL, shiny = TRUE,
+                                       title = NULL, ...) {
   if (is.null(Rmd_file) && rstudioapi::isAvailable()) {
     Rmd_file <- rstudioapi::getSourceEditorContext()$path
     if (identical(Rmd_file, "")) {
@@ -56,11 +57,24 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL) {
 
   front_matter <- rmarkdown::yaml_front_matter(Rmd_file, "UTF-8")
 
-  confl_addin_upload(
-    md_file = md_file,
-    title = front_matter$title,
-    tags = front_matter$tags
-  )
+  if (!is.null(title)) {
+    front_matter$title <- title
+  }
+
+  if (shiny) {
+    confl_addin_upload(
+      md_file = md_file,
+      title = front_matter$title,
+      tags = front_matter$tags
+    )
+  } else {
+    confl_console_upload(
+      md_file = md_file,
+      title = front_matter$title,
+      tags = front_matter$tags,
+      ...
+    )
+  }
 }
 
 confl_addin_upload <- function(md_file, title, tags) {

--- a/R/console.R
+++ b/R/console.R
@@ -1,0 +1,86 @@
+# Copyright (C) 2019 LINE Corporation
+#
+# conflr is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# conflr is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See <http://www.gnu.org/licenses/> for more details.
+
+confl_console_upload <- function(md_file, title, tags, space_key, type,
+                                 parent_id, update = FALSE, use_original_size) {
+
+  # conflr doesn't insert a title in the content automatically
+  md_text <- read_utf8(md_file)
+  html_text <- commonmark::markdown_html(md_text)
+
+  md_dir <- dirname(md_file)
+  imgs <- extract_image_paths(html_text)
+  imgs <- curl::curl_unescape(imgs)
+  # imgs might be absolute, relative to md_dir, or relative to the current dir.
+  imgs_realpath <- ifelse(file.exists(imgs), imgs, file.path(md_dir, imgs))
+
+  html_text_for_preview <- embed_images(html_text, imgs, imgs_realpath)
+
+  # Extracted Shiny Code
+  # check if there is an existing page
+  existing_pages <- confl_list_pages(title = title, spaceKey = space_key)
+  if (existing_pages$size == 0) {
+    # if the page doesn't exist, create a blank page
+    blank_page <- confl_post_page(
+      type = type,
+      spaceKey = space_key,
+      title = title,
+      body = "",
+      ancestors = parent_id
+    )
+    id <- blank_page$id
+  } else {
+    if (!update) {
+      stop("Page already exists. Re-run with `update = TRUE` to overwrite.",
+           call. = FALSE)
+    }
+
+    id <- existing_pages$results[[1]]$id
+  }
+
+  # Step 1) Upload Images
+  message("Checking the existing images...")
+
+  # Check if the images already exist
+  imgs_exist <- confl_list_attachments(id)
+  imgs_exist_ids <- purrr::map_chr(imgs_exist$results, "id")
+  names(imgs_exist_ids) <- purrr::map_chr(imgs_exist$results, "title")
+
+  message("Uploading the images...")
+  num_imgs <- length(imgs)
+  for (i in seq_along(imgs)) {
+
+    # attempt to avoid rate limits
+    Sys.sleep(0.2)
+
+    img_id <- imgs_exist_ids[basename(imgs[i])]
+    if (is.na(img_id)) {
+      confl_post_attachment(id, imgs_realpath[i])
+    } else {
+      confl_update_attachment_data(id, img_id, imgs_realpath[i])
+    }
+  }
+
+  # Step 2) Upload the document
+  message("Uploading the document...")
+
+  image_size_default <- if (!use_original_size) 600 else NULL
+  result <- confl_update_page(
+    id = id,
+    title = title,
+    body = html_text,
+    image_size_default = image_size_default
+  )
+
+  message("Done!")
+  Sys.sleep(2)
+
+  message(paste0("Results at: ", result$`_links`$base, result$`_links`$webui))
+}

--- a/R/console.R
+++ b/R/console.R
@@ -82,5 +82,7 @@ confl_console_upload <- function(md_file, title, tags, space_key, type,
   message("Done!")
   Sys.sleep(2)
 
-  message(paste0("Results at: ", result$`_links`$base, result$`_links`$webui))
+  results_url <- paste0(result$`_links`$base, result$`_links`$webui)
+  message(paste0("Results at: ", results_url))
+  results_url
 }

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -4,10 +4,15 @@
 \alias{confl_create_post_from_Rmd}
 \title{Publish R Markdown Document to 'Confluence'}
 \usage{
-confl_create_post_from_Rmd(Rmd_file = NULL)
+confl_create_post_from_Rmd(Rmd_file = NULL,
+  interactive = interactive(), title = NULL, ...)
 }
 \arguments{
 \item{Rmd_file}{path to a .Rmd file. If \code{NULL}, use the active document.}
+
+\item{interactive}{If \code{FALSE} shiny interface is not launched.}
+
+\item{...}{Addtional arguments passed to \code{\link[=confl_console_upload]{confl_console_upload()}}.}
 }
 \description{
 Knit and post a given R Markdown file to 'Confluence'.

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -12,7 +12,9 @@ confl_create_post_from_Rmd(Rmd_file = NULL,
 
 \item{interactive}{If \code{FALSE} shiny interface is not launched.}
 
-\item{...}{Addtional arguments passed to \code{\link[=confl_console_upload]{confl_console_upload()}}.}
+\item{title}{If provided this overwrites the YAML front matter title.}
+
+\item{...}{Addtional arguments passed to \code{confl_console_upload()}.}
 }
 \description{
 Knit and post a given R Markdown file to 'Confluence'.


### PR DESCRIPTION
Hello again!

I was wanting to automate a page upload to confluence, but the current setup page upload flow requires going through the shiny app. In order to enable scriptable uploading I made a few changes:

1) Added `confl_console_upload()` in `console.R` that is essentially just the server-side code from the shiny app on its own. I made the options in the Shiny app into function arguments. Also, the function returns the url of the published page for further scripting (e.g. notification to others).

2) Added a `shiny` argument to `confl_create_post_from_Rmd()` that when set to `FALSE` uses the new console upload function for publishing instead of `confl_addin_upload()`. Also added `...` to pass the needed arguments down to the console upload function.

3) Added an optional `title` argument to `confl_create_post_from_Rmd()` to allow for programmatic naming of the page on Confluence.

Also this allows for a script like this:
```
library(conflr)

confl_create_post_from_Rmd(
  "~/Desktop/test_ups.Rmd",
  shiny = FALSE,
  title = paste0(Sys.Date(), " Test Page"),
  space_key = "NDQ",
  parent_id = 232580,
  update = TRUE,
  use_original_size = TRUE,
  type = "page"
)
```

Did my best to follow your conventions, but of course totally open to any changes! Thanks for your work on this useful package!