### PR TITLE
Do not use interactive() as the default argument

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -19,8 +19,12 @@
 #' @param ... Addtional arguments passed to `confl_console_upload()`.
 #'
 #' @export
-confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = interactive(),
+confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
                                        title = NULL, ...) {
+  if (is.null(interactive)) {
+    interactive <- interactive()
+  }
+
   if (is.null(Rmd_file) && rstudioapi::isAvailable()) {
     Rmd_file <- rstudioapi::getSourceEditorContext()$path
     if (identical(Rmd_file, "")) {

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -4,8 +4,8 @@
 \alias{confl_create_post_from_Rmd}
 \title{Publish R Markdown Document to 'Confluence'}
 \usage{
-confl_create_post_from_Rmd(Rmd_file = NULL,
-  interactive = interactive(), title = NULL, ...)
+confl_create_post_from_Rmd(Rmd_file = NULL, interactive = NULL,
+  title = NULL, ...)
 }
 \arguments{
 \item{Rmd_file}{path to a .Rmd file. If \code{NULL}, use the active document.}


### PR DESCRIPTION
Fix this error: https://stackoverflow.com/questions/57068756/cant-publish-r-mardown-to-confluence-using-conflr

(Not sure about the detail, but it seems we should avoid using `interactive()` as the default argument)