### PR TITLE
Specify the knit environment as global

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -59,7 +59,11 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
       pandoc_args = "--wrap=none",
       md_extensions = "-tex_math_single_backslash-tex_math_dollars-raw_tex"
     ),
-    encoding = "UTF-8"
+    encoding = "UTF-8",
+    # TODO: I'm not fully sure the global env is always the right place to knit, but this is needed to avoid
+    #       an error related to data.table (#29). If this doesn't work, I need to add this code (c.f. https://github.com/Rdatatable/data.table/blob/5ceda0f383f91b7503d4a236ee4e7438724340be/R/cedta.R#L13):
+    #   assignInNamespace("cedta.pkgEvalsUserCode", c(data.table:::cedta.pkgEvalsUserCode, "conflr"), "data.table")
+    env = globalenv()
   )
 
   front_matter <- rmarkdown::yaml_front_matter(Rmd_file, "UTF-8")


### PR DESCRIPTION
(Fix #29)

According to https://github.com/Rdatatable/data.table/blob/5ceda0f383f91b7503d4a236ee4e7438724340be/R/cedta.R#L4-L20, I have two choice to fix this problem:

1. Specify `assignInNamespace("cedta.pkgEvalsUserCode", c(data.table:::cedta.pkgEvalsUserCode,"<nsname>"), "data.table")` to tell data.table to aware of conflr (?)
2. Specify the knit environment as the global environment, where data.table is supposed to work fine.

Not fully understand the problem, but this PR chose the option 2 because I want to avoid introducing package-dependent codes. I hope this change won't cause any harm...