### PR TITLE
Do not translate external image to Conflence macro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 * `confl_create_post_from_Rmd()` gets `params` argument for parameterized R
   Markdown (#37, @ellisvalentiner).
 
+* External images are now converted properly (#39).
+
 # conflr 0.0.5
 
 * Initial release on GitHub

--- a/R/translate.R
+++ b/R/translate.R
@@ -146,6 +146,11 @@ replace_image <- function(x, image_size_default = 600) {
       next()
     }
 
+    # skip external files
+    if (startsWith(src, "http")) {
+      next()
+    }
+
     # construct height and width params (e.g. ac:height="400" ac:width="300")
     hw <- list(
       width = img_attrs$width %||% image_size_default,

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -139,6 +139,12 @@ test_that("replace_image() works", {
     replace_image('<img src="/path/to/img.png" />', image_size_default = NULL),
     '<ac:image ><ri:attachment ri:filename="img.png" /></ac:image>'
   )
+
+  # external images are not converted
+  expect_equal(
+    replace_image('<img src="https://example.com/img.png" />', image_size_default = NULL),
+    '<img src="https://example.com/img.png" />'
+  )
 })
 
 test_that("translate_to_confl_macro() works", {


### PR DESCRIPTION
If the `src` of a `<img>` tag is external, conflr should nothing on it, because Confluence will handle it. Currently, it's mistranslated as below, which is a clear mistake...

``` xml
<ac:image ac:width="600"><ri:attachment ri:filename="..." /></ac:image>
```