### PR TITLE
uncache password after upload post

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -89,6 +89,8 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
       ...
     )
   }
+  
+  Sys.unsetenv("CONFLUENCE_PASSWORD")
 }
 
 confl_addin_upload <- function(md_file, title, tags) {


### PR DESCRIPTION
after wiki post, Sys.getenv("CONFLUENCE_PASSWORD") shows password as plain text : so uncache password after post upload