### PR TITLE
Add an option not to chace the URL username and password as envvars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@
 
 * External images are now converted properly (#39).
 
+* Add an option `conflr_dont_cache_envvar` not to cache the URL, username and
+  password as envvars (#41).
+
 # conflr 0.0.5
 
 * Initial release on GitHub

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 * External images are now converted properly (#39).
 
 * Add an option `conflr_dont_cache_envvar` not to cache the URL, username and
-  password as envvars (#41).
+  password as envvars (#43).
 
 # conflr 0.0.5
 

--- a/R/util.R
+++ b/R/util.R
@@ -67,10 +67,12 @@ confl_verb <- function(verb, path, ...) {
     )
   }
 
-  # If the request succeeds, cache the credentials.
-  Sys.setenv(CONFLUENCE_URL = base_url)
-  Sys.setenv(CONFLUENCE_USERNAME = username)
-  Sys.setenv(CONFLUENCE_PASSWORD = password)
+  # If the request succeeds, cache the credentials except when the user explicitly choose not to.
+  if (!isTRUE(getOption("conflr_dont_cache_envvar"))) {
+    Sys.setenv(CONFLUENCE_URL = base_url)
+    Sys.setenv(CONFLUENCE_USERNAME = username)
+    Sys.setenv(CONFLUENCE_PASSWORD = password)
+  }
 
   res
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -36,7 +36,11 @@ conflr uses these environmental variables to access your Confluence.
 * `CONFLUENCE_USERNAME`: Your username (On Atlassian Cloud, your email address).
 * `CONFLUENCE_PASSWORD`: Your password (On Atlassian Cloud, your API token. For more details about API token, please read [the official document](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)).
 
-There are several ways to set these environmental variables. The quickest way is to enter in the popups that are displayed when you run the install command (see Usages section below).
+There are several ways to set these environmental variables. The quickest way is to enter in the popups that are displayed when you run the addin (see Usages section below). The inputs are cached in the environmental variables listed above by default. If you don't want to cache them, please set the following option.
+
+```{r options, eval=FALSE}
+options(conflr_dont_cache_envvar = TRUE)
+```
 
 Another way is to set the variables in the `.Renviron` file (you can open the file with `usethis::edit_r_environ()`). For example, you can set the base URL in the file as the following.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ conflr uses these environmental variables to access your Confluence.
 
 There are several ways to set these environmental variables. The
 quickest way is to enter in the popups that are displayed when you run
-the install command (see Usages section below).
+the addin (see Usages section below). The inputs are cached in the
+environmental variables listed above by default. If you don’t want to
+cache them, please set the following option.
+
+``` r
+options(conflr_dont_cache_envvar = TRUE)
+```
 
 Another way is to set the variables in the `.Renviron` file (you can
 open the file with `usethis::edit_r_environ()`). For example, you can

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -56,4 +56,29 @@ test_that("confl_verb() asks for credentials if it is not set", {
 
   mockery::expect_called(mock_ask2, 1)
   mockery::expect_call(mock_ask2, n = 1, ask_confluence_url())
+
+  # do not cache when options(conflr_dont_cache_envvar) is set FALSE
+  mock_ask3 <- mockery::mock("foo")
+
+  with_mock(
+    "httr::VERB" = mock_success,
+    "conflr::ask_confluence_url" = mock_ask3,
+    "conflr::ask_confluence_username" = mock_ask3,
+    "conflr::ask_confluence_password" = mock_ask3,
+    withr::with_options(
+      list(conflr_dont_cache_envvar = TRUE),
+      withr::with_envvar(
+        list(CONFLUENCE_URL = "", CONFLUENCE_USERNAME = "user", CONFLUENCE_PASSWORD = "pass"), {
+          confl_verb("GET", "/")
+          expect_equal(Sys.getenv("CONFLUENCE_URL"), "")
+          # ensure the option doesn't affect on the envvars that are already set
+          expect_equal(Sys.getenv("CONFLUENCE_USERNAME"), "user")
+          expect_equal(Sys.getenv("CONFLUENCE_PASSWORD"), "pass")
+        }
+      )
+    )
+  )
+
+  mockery::expect_called(mock_ask3, 1)
+  mockery::expect_call(mock_ask3, n = 1, ask_confluence_url())
 })


### PR DESCRIPTION
Close #42 (for the details, see the discussion on #41)

Users are now able to choose not to cache the input in the envvars by setting this option:

``` r
options(conflr_dont_cache_envvar = TRUE)
```