### PR TITLE
Add the ability to write post-settings on Rmd

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -73,37 +73,37 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
   # set confl setting
   front_matter <- rmarkdown::yaml_front_matter(Rmd_file, "UTF-8")
 
-  confluence_setting <- purrr::list_modify(front_matter$confluence_setting, ...)
+  confluence_settings <- purrr::list_modify(front_matter$confluence_settings, ...)
 
-  confluence_setting$title <- title %||% front_matter$title
+  confluence_settings$title <- title %||% front_matter$title
 
   if (!interactive) {
-    if (is.null(confluence_setting$update)) {
-      confluence_setting$update <- FALSE
+    if (is.null(confluence_settings$update)) {
+      confluence_settings$update <- FALSE
     }
-    if (is.null(confluence_setting$use_origin_size)) {
-      confluence_setting$use_original_size <- FALSE
+    if (is.null(confluence_settings$use_origin_size)) {
+      confluence_settings$use_original_size <- FALSE
     }
   }
 
   if (interactive) {
     confl_addin_upload(
       md_file = md_file,
-      title = confluence_setting$title,
-      tags = confluence_setting$tags,
-      space_key = confluence_setting$space_key,
-      parent_id = confluence_setting$parent_id
+      title = confluence_settings$title,
+      tags = confluence_settings$tags,
+      space_key = confluence_settings$space_key,
+      parent_id = confluence_settings$parent_id
     )
   } else {
     confl_console_upload(
       md_file = md_file,
-      title = confluence_setting$title,
-      tags = confluence_setting$tags,
-      space_key = confluence_setting$space_key,
-      type = confluence_setting$type,
-      parent_id = confluence_setting$parent_id,
-      update = confluence_setting$update,
-      use_original_size = confluence_setting$use_original_size
+      title = confluence_settings$title,
+      tags = confluence_settings$tags,
+      space_key = confluence_settings$space_key,
+      type = confluence_settings$type,
+      parent_id = confluence_settings$parent_id,
+      update = confluence_settings$update,
+      use_original_size = confluence_settings$use_original_size
     )
   }
 }

--- a/R/addin.R
+++ b/R/addin.R
@@ -23,6 +23,9 @@
 #' @export
 confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
                                        title = NULL, params = NULL, ...) {
+
+  args <- list(...)
+
   if (is.null(interactive)) {
     interactive <- interactive()
   }
@@ -83,40 +86,40 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
     confl_setting$title <- front_matter$title
   }
 
-  if (!is.null(tags)) {
-    confl_setting$tags <- tags
+  if (!is.null(args$tags)) {
+    confl_setting$tags <- args$tags
   } else {
     confl_setting <- front_matter_confl$tags
   }
 
-  if (!is.null(space_key)) {
-    confl_setting$space_key <- space_key
+  if (!is.null(args$space_key)) {
+    confl_setting$space_key <- args$space_key
   } else {
     confl_setting$space_key <- front_matter_confl$space_key
   }
 
-  if (!is.null(parent_id)) {
-    confl_setting$parent_id <- parent_id
+  if (!is.null(args$parent_id)) {
+    confl_setting$parent_id <- args$parent_id
   } else {
     confl_setting$parent_id <- front_matter_confl$parent_id
   }
 
   # set confl_setting for console
   if (!interactive) {
-    if (!is.null(type)) {
-      confl_setting$type <- type
+    if (!is.null(args$type)) {
+      confl_setting$type <- args$type
     } else {
       confl_setting$type <- front_matter_confl$type
     }
 
-    if (!is.null(update)) {
-      confl_setting$update <- update
+    if (!is.null(args$update)) {
+      confl_setting$update <- args$update
     } else {
       confl_setting$update <- front_matter_confl$update
     }
 
-    if (!is.null(use_original_size)) {
-      confl_setting$use_original_size <- use_original_size
+    if (!is.null(args$use_original_size)) {
+      confl_setting$use_original_size <- args$use_original_size
     } else {
       confl_setting$use_original_size <- front_matter_confl$use_original_size
     }

--- a/R/addin.R
+++ b/R/addin.R
@@ -174,7 +174,7 @@ confl_addin_upload <- function(md_file, title, tags, space_key = NULL, parent_id
           width = 2,
           shiny::textInput(
             inputId = "spaceKey", label = "Space Key",
-            value = ifelse(!is.null(space_key), space_key, try_get_personal_space_key())
+            value = space_key %||% try_get_personal_space_key()
           )
         ),
         shiny::column(

--- a/R/addin.R
+++ b/R/addin.R
@@ -113,7 +113,7 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
       confl_setting$update <- front_matter_confl$update
     }
 
-    if (!is.null(!use_original_size)) {
+    if (!is.null(use_original_size)) {
       confl_setting$use_original_size <- use_original_size
     } else {
       confl_setting$use_original_size <- front_matter_confl$use_original_size

--- a/R/addin.R
+++ b/R/addin.R
@@ -74,6 +74,8 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
 
   front_matter_confl <- front_matter$confl_setting
 
+  confl_setting <- c()
+
   # set confl setting: base
   if (!is.null(title)) {
     confl_setting$title <- title

--- a/R/addin.R
+++ b/R/addin.R
@@ -69,29 +69,81 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
     env = globalenv()
   )
 
+  # set confl setting
   front_matter <- rmarkdown::yaml_front_matter(Rmd_file, "UTF-8")
 
+  front_matter_confl <- front_matter$confl_setting
+
+  # set confl setting: base
   if (!is.null(title)) {
-    front_matter$title <- title
+    confl_setting$title <- title
+  } else {
+    confl_setting$title <- front_matter$title
   }
+
+  if (!is.null(tags)) {
+    confl_setting$tags <- tags
+  } else {
+    confl_setting <- front_matter_confl$tags
+  }
+
+  if (!is.null(space_key)) {
+    confl_setting$space_key <- space_key
+  } else {
+    confl_setting$space_key <- front_matter_confl$space_key
+  }
+
+  if (!is.null(parent_id)) {
+    confl_setting$parent_id <- parent_id
+  } else {
+    confl_setting$parent_id <- front_matter_confl$parent_id
+  }
+
+  # set confl_setting for console
+  if (!interactive) {
+    if (!is.null(type)) {
+      confl_setting$type <- type
+    } else {
+      confl_setting$type <- front_matter_confl$type
+    }
+
+    if (!is.null(update)) {
+      confl_setting$update <- update
+    } else {
+      confl_setting$update <- front_matter_confl$update
+    }
+
+    if (!is.null(!use_original_size)) {
+      confl_setting$use_original_size <- use_original_size
+    } else {
+      confl_setting$use_original_size <- front_matter_confl$use_original_size
+    }
+  }
+
 
   if (interactive) {
     confl_addin_upload(
       md_file = md_file,
-      title = front_matter$title,
-      tags = front_matter$tags
+      title = confl_setting$title,
+      tags = confl_setting$tags,
+      space_key = confl_setting$space_key,
+      parent_id = confl_setting$parent_id
     )
   } else {
     confl_console_upload(
       md_file = md_file,
-      title = front_matter$title,
-      tags = front_matter$tags,
-      ...
+      title = confl_setting$title,
+      tags = confl_setting$tags,
+      space_key = confl_setting$space_key,
+      type = confl_setting$type,
+      parent_id = confl_setting$parent_id,
+      update = confl_setting$update,
+      use_original_size = confl_setting$use_original_size
     )
   }
 }
 
-confl_addin_upload <- function(md_file, title, tags) {
+confl_addin_upload <- function(md_file, title, tags, space_key, parent_id) {
   # conflr doesn't insert a title in the content automatically
   md_text <- read_utf8(md_file)
   html_text <- commonmark::markdown_html(md_text)
@@ -115,21 +167,21 @@ confl_addin_upload <- function(md_file, title, tags) {
           width = 2,
           shiny::selectInput(
             inputId = "type", label = "Type",
-            choices = eval(formals(confl_post_page)$type),
+            choices = eval(formals(confl_post_page)$type)
           )
         ),
         shiny::column(
           width = 2,
           shiny::textInput(
             inputId = "spaceKey", label = "Space Key",
-            value = try_get_personal_space_key()
+            value = ifelse(!is.null(space_key), space_key, try_get_personal_space_key())
           )
         ),
         shiny::column(
           width = 2,
           shiny::textInput(
             inputId = "ancestors", label = "Parent page ID",
-            value = NULL
+            value = parent_id
           )
         ),
         shiny::column(

--- a/R/addin.R
+++ b/R/addin.R
@@ -143,7 +143,7 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
   }
 }
 
-confl_addin_upload <- function(md_file, title, tags, space_key, parent_id) {
+confl_addin_upload <- function(md_file, title, tags, space_key = NULL, parent_id = NULL) {
   # conflr doesn't insert a title in the content automatically
   md_text <- read_utf8(md_file)
   html_text <- commonmark::markdown_html(md_text)

--- a/R/addin.R
+++ b/R/addin.R
@@ -24,8 +24,6 @@
 confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
                                        title = NULL, params = NULL, ...) {
 
-  args <- list(...)
-
   if (is.null(interactive)) {
     interactive <- interactive()
   }
@@ -75,56 +73,20 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
   # set confl setting
   front_matter <- rmarkdown::yaml_front_matter(Rmd_file, "UTF-8")
 
-  front_matter_confl <- front_matter$confl_setting
+  confl_setting <- purrr::list_modify(front_matter$confl_setting, ...)
 
-  confl_setting <- c()
-
-  # set confl setting: base
-  if (!is.null(title)) {
-    confl_setting$title <- title
-  } else {
+  if (is.null(confl_setting$title)) {
     confl_setting$title <- front_matter$title
   }
 
-  if (!is.null(args$tags)) {
-    confl_setting$tags <- args$tags
-  } else {
-    confl_setting <- front_matter_confl$tags
-  }
-
-  if (!is.null(args$space_key)) {
-    confl_setting$space_key <- args$space_key
-  } else {
-    confl_setting$space_key <- front_matter_confl$space_key
-  }
-
-  if (!is.null(args$parent_id)) {
-    confl_setting$parent_id <- args$parent_id
-  } else {
-    confl_setting$parent_id <- front_matter_confl$parent_id
-  }
-
-  # set confl_setting for console
   if (!interactive) {
-    if (!is.null(args$type)) {
-      confl_setting$type <- args$type
-    } else {
-      confl_setting$type <- front_matter_confl$type
+    if (is.null(confl_setting$update)) {
+      confl_setting$update <- FALSE
     }
-
-    if (!is.null(args$update)) {
-      confl_setting$update <- args$update
-    } else {
-      confl_setting$update <- front_matter_confl$update
-    }
-
-    if (!is.null(args$use_original_size)) {
-      confl_setting$use_original_size <- args$use_original_size
-    } else {
-      confl_setting$use_original_size <- front_matter_confl$use_original_size
+    if (is.null(confl_setting$use_origin_size)) {
+      confl_setting$use_original_size <- FALSE
     }
   }
-
 
   if (interactive) {
     confl_addin_upload(
@@ -164,7 +126,7 @@ confl_addin_upload <- function(md_file, title, tags, space_key = NULL, parent_id
   # Shiny UI -----------------------------------------------------------
   ui <- miniUI::miniPage(
     miniUI::gadgetTitleBar("Preview",
-      right = miniUI::miniTitleBarButton("done", "Publish", primary = TRUE)
+                           right = miniUI::miniTitleBarButton("done", "Publish", primary = TRUE)
     ),
     miniUI::miniContentPanel(
       shiny::fluidRow(

--- a/R/addin.R
+++ b/R/addin.R
@@ -73,39 +73,37 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
   # set confl setting
   front_matter <- rmarkdown::yaml_front_matter(Rmd_file, "UTF-8")
 
-  confl_setting <- purrr::list_modify(front_matter$confl_setting, ...)
+  confluence_setting <- purrr::list_modify(front_matter$confluence_setting, ...)
 
-  if (is.null(confl_setting$title)) {
-    confl_setting$title <- front_matter$title
-  }
+  confluence_setting$title <- title %||% front_matter$title
 
   if (!interactive) {
-    if (is.null(confl_setting$update)) {
-      confl_setting$update <- FALSE
+    if (is.null(confluence_setting$update)) {
+      confluence_setting$update <- FALSE
     }
-    if (is.null(confl_setting$use_origin_size)) {
-      confl_setting$use_original_size <- FALSE
+    if (is.null(confluence_setting$use_origin_size)) {
+      confluence_setting$use_original_size <- FALSE
     }
   }
 
   if (interactive) {
     confl_addin_upload(
       md_file = md_file,
-      title = confl_setting$title,
-      tags = confl_setting$tags,
-      space_key = confl_setting$space_key,
-      parent_id = confl_setting$parent_id
+      title = confluence_setting$title,
+      tags = confluence_setting$tags,
+      space_key = confluence_setting$space_key,
+      parent_id = confluence_setting$parent_id
     )
   } else {
     confl_console_upload(
       md_file = md_file,
-      title = confl_setting$title,
-      tags = confl_setting$tags,
-      space_key = confl_setting$space_key,
-      type = confl_setting$type,
-      parent_id = confl_setting$parent_id,
-      update = confl_setting$update,
-      use_original_size = confl_setting$use_original_size
+      title = confluence_setting$title,
+      tags = confluence_setting$tags,
+      space_key = confluence_setting$space_key,
+      type = confluence_setting$type,
+      parent_id = confluence_setting$parent_id,
+      update = confluence_setting$update,
+      use_original_size = confluence_setting$use_original_size
     )
   }
 }


### PR DESCRIPTION
This PR is to add the ability to write post-settings on Rmd's yaml-front-matter.
Example is here:

```yaml
---
title: "conflr post test"
confl_setting:
  tags: "hoge"
  space_key: "my_space"
  parent_id: "123456789"
  type: "page"
  update: TRUE
  use_original_size: FALSE
---
```
  