### PR TITLE
fix a bug on use_original_size

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -87,7 +87,7 @@ confl_create_post_from_Rmd <- function(Rmd_file = NULL, interactive = NULL,
     if (is.null(confluence_settings$update)) {
       confluence_settings$update <- FALSE
     }
-    if (is.null(confluence_settings$use_origin_size)) {
+    if (is.null(confluence_settings$use_original_size)) {
       confluence_settings$use_original_size <- FALSE
     }
   }


### PR DESCRIPTION
There is a bug on `use_original_size` using `confl_create_post_from_Rmd()` with `interactive = FALSE`.
This PR is to fix it.