### PR TITLE
Support TOC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,9 @@
 * A new function `confl_contentbody_convert()` converts the Confluence-related
   formats by using the Confluence REST API (#58).
 
+* `confl_create_post_from_Rmd()` gets `interactive` argument. When it's `TRUE`,
+  TOC is added at the top of the document (#64)
+
 # conflr 0.0.5
 
 * Initial release on GitHub

--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -83,7 +83,7 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
   progress$set(message = "Uploading the document...")
 
   if (toc) {
-    html_text <- paste0('<p><ac:structured-macro ac:name="toc" /></p>', html_text)
+    html_text <- paste0('<p><ac:structured-macro ac:name="toc" /></p>\n', html_text)
   }
 
   image_size_default <- if (!use_original_size) 600 else NULL

--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -10,7 +10,7 @@
 
 confl_upload <- function(title, space_key, type, parent_id, html_text,
                          imgs, imgs_realpath,
-                         update = NULL, use_original_size = FALSE,
+                         toc = FALSE, update = NULL, use_original_size = FALSE,
                          interactive = NULL, session = NULL) {
   if (is.null(interactive)) {
     interactive <- interactive()
@@ -81,6 +81,10 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
 
   # Step 2) Upload the document
   progress$set(message = "Uploading the document...")
+
+  if (toc) {
+    html_text <- paste0('<p><ac:structured-macro ac:name="toc" /></p>', html_text)
+  }
 
   image_size_default <- if (!use_original_size) 600 else NULL
   result <- confl_update_page(

--- a/R/addin.R
+++ b/R/addin.R
@@ -162,7 +162,8 @@ confl_create_post_from_Rmd <- function(
       imgs_realpath = imgs_realpath,
       toc = confluence_settings$toc %||% FALSE,
       update = confluence_settings$update,
-      use_original_size = confluence_settings$use_original_size %||% FALSE
+      use_original_size = confluence_settings$use_original_size %||% FALSE,
+      interactive = interactive
     )
   }
 }

--- a/R/addin.R
+++ b/R/addin.R
@@ -143,7 +143,9 @@ confl_create_post_from_Rmd <- function(
       parent_id = confluence_settings$parent_id,
       html_text = html_text,
       imgs = imgs,
-      imgs_realpath = imgs_realpath
+      imgs_realpath = imgs_realpath,
+      toc = confluence_settings$toc %||% FALSE,
+      use_original_size = confluence_settings$use_original_size %||% FALSE
     )
 
     # if the user doesn't want to store the password as envvar, clear it.
@@ -182,7 +184,10 @@ confl_create_post_from_Rmd_addin <- function() {
   confl_create_post_from_Rmd(Rmd_file, interactive = TRUE)
 }
 
-confl_upload_interactively <- function(title, space_key, type, parent_id, html_text, imgs, imgs_realpath) {
+confl_upload_interactively <- function(title, space_key, type, parent_id, html_text,
+                                       imgs, imgs_realpath,
+                                       toc = FALSE, use_original_size = FALSE) {
+
   # Shiny UI -----------------------------------------------------------
   ui <- confl_addin_ui(
     title = title,
@@ -191,7 +196,9 @@ confl_upload_interactively <- function(title, space_key, type, parent_id, html_t
     parent_id = parent_id,
     html_text = html_text,
     imgs = imgs,
-    imgs_realpath = imgs_realpath
+    imgs_realpath = imgs_realpath,
+    toc = toc,
+    use_original_size = use_original_size
   )
 
   # Shiny Server -------------------------------------------------------
@@ -251,7 +258,9 @@ wrap_with_column <- function(..., width = 2) {
   shiny::column(width = width, ...)
 }
 
-confl_addin_ui <- function(title, space_key, type, parent_id, html_text, imgs, imgs_realpath) {
+confl_addin_ui <- function(title, space_key, type, parent_id, html_text,
+                           imgs, imgs_realpath,
+                           toc = FALSE, use_original_size = FALSE) {
   # title bar
   title_bar_button <- miniUI::miniTitleBarButton("done", "Publish", primary = TRUE)
   title_bar <- miniUI::gadgetTitleBar("Preview", right = title_bar_button)
@@ -266,10 +275,10 @@ confl_addin_ui <- function(title, space_key, type, parent_id, html_text, imgs, i
   parent_id_input <- shiny::textInput(inputId = "parent_id", label = "Parent page ID", value = parent_id)
 
   # use the original size or not
-  use_original_size_input <- shiny::checkboxInput(inputId = "use_original_size", label = "Use original image sizes", value = FALSE)
+  use_original_size_input <- shiny::checkboxInput(inputId = "use_original_size", label = "Use original image sizes", value = use_original_size)
 
   # add TOC or not
-  toc_input <- shiny::checkboxInput(inputId = "toc", label = "TOC", value = FALSE)
+  toc_input <- shiny::checkboxInput(inputId = "toc", label = "TOC", value = toc)
 
   # Preview
   html_text_for_preview <- embed_images(html_text, imgs, imgs_realpath)

--- a/R/addin.R
+++ b/R/addin.R
@@ -108,6 +108,7 @@ confl_create_post_from_Rmd <- function(
     space_key = space_key,
     type = type,
     parent_id = parent_id,
+    toc = toc,
     update = update,
     use_original_size = use_original_size
   )

--- a/R/addin.R
+++ b/R/addin.R
@@ -21,14 +21,15 @@
 #' @param type If provided, this overwrites the YAML front matter type
 #' @param space_key The space key to find content under.
 #' @param parent_id The page ID of the parent pages.
+#' @param toc If `TRUE`, add TOC.
 #' @param update If `TRUE`, overwrite the existing page (if it exists).
 #' @param use_original_size If `TRUE`, use the original image sizes.
 #'
 #' @details
-#' `title`, `type`, `space_key`, `parent_id`, `update`, and `use_original_size`
-#' can be specified as `confluence_settings` item in the front-matter of the
-#' Rmd file to knit. The arguments of `confl_create_post_from_Rmd()` overwrite
-#' these settings if provided.
+#' `title`, `type`, `space_key`, `parent_id`, `toc`, `update`, and
+#' `use_original_size` can be specified as `confluence_settings` item in the
+#' front-matter of the Rmd file to knit. The arguments of
+#' `confl_create_post_from_Rmd()` overwrite these settings if provided.
 #'
 #' @export
 confl_create_post_from_Rmd <- function(
@@ -42,6 +43,7 @@ confl_create_post_from_Rmd <- function(
   space_key = NULL,
   type = NULL,
   parent_id = NULL,
+  toc = NULL,
   update = NULL,
   use_original_size = NULL) {
 
@@ -157,6 +159,7 @@ confl_create_post_from_Rmd <- function(
       html_text = html_text,
       imgs = imgs,
       imgs_realpath = imgs_realpath,
+      toc = confluence_settings$toc %||% FALSE,
       update = confluence_settings$update,
       use_original_size = confluence_settings$use_original_size %||% FALSE
     )
@@ -207,6 +210,7 @@ confl_upload_interactively <- function(title, space_key, type, parent_id, html_t
         html_text = html_text,
         imgs = imgs,
         imgs_realpath = imgs_realpath,
+        toc = input$toc,
         use_original_size = input$use_original_size
       )
     })
@@ -262,6 +266,9 @@ confl_addin_ui <- function(title, space_key, type, parent_id, html_text, imgs, i
   # use the original size or not
   use_original_size_input <- shiny::checkboxInput(inputId = "use_original_size", label = "Use original image sizes", value = FALSE)
 
+  # add TOC or not
+  toc_input <- shiny::checkboxInput(inputId = "toc", label = "TOC", value = FALSE)
+
   # Preview
   html_text_for_preview <- embed_images(html_text, imgs, imgs_realpath)
   preview_html <- shiny::HTML(html_text_for_preview)
@@ -273,7 +280,7 @@ confl_addin_ui <- function(title, space_key, type, parent_id, html_text, imgs, i
         wrap_with_column(type_input),
         wrap_with_column(space_key_input),
         wrap_with_column(parent_id_input),
-        wrap_with_column(use_original_size_input, width = 4)
+        wrap_with_column(use_original_size_input, toc_input, width = 4)
       ),
       shiny::hr(),
       shiny::h1(title, align = "center"),

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -13,6 +13,7 @@ confl_create_post_from_Rmd(
   space_key = NULL,
   type = NULL,
   parent_id = NULL,
+  toc = NULL,
   update = NULL,
   use_original_size = NULL
 )
@@ -35,6 +36,8 @@ params in the YAML front-matter.}
 
 \item{parent_id}{The page ID of the parent pages.}
 
+\item{toc}{If \code{TRUE}, add TOC.}
+
 \item{update}{If \code{TRUE}, overwrite the existing page (if it exists).}
 
 \item{use_original_size}{If \code{TRUE}, use the original image sizes.}
@@ -43,8 +46,8 @@ params in the YAML front-matter.}
 Knit and post a given R Markdown file to 'Confluence'.
 }
 \details{
-\code{title}, \code{type}, \code{space_key}, \code{parent_id}, \code{update}, and \code{use_original_size}
-can be specified as \code{confluence_settings} item in the front-matter of the
-Rmd file to knit. The arguments of \code{confl_create_post_from_Rmd()} overwrite
-these settings if provided.
+\code{title}, \code{type}, \code{space_key}, \code{parent_id}, \code{toc}, \code{update}, and
+\code{use_original_size} can be specified as \code{confluence_settings} item in the
+front-matter of the Rmd file to knit. The arguments of
+\code{confl_create_post_from_Rmd()} overwrite these settings if provided.
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,3 @@
+should_not_be_called <- function(...) {
+  stop(deparse(match.call()[[1]]), "() should not be called", call. = FALSE)
+}

--- a/tests/testthat/test-front-matter.R
+++ b/tests/testthat/test-front-matter.R
@@ -30,6 +30,7 @@ Rmd_with_all_defaults <-
 confluence_settings:
   space_key: "space1"
   parent_id: 1234
+  toc: TRUE
   update: TRUE
   use_original_size: TRUE'
 
@@ -44,6 +45,7 @@ test_that("confluence_settings can be set from front-matter", {
     title = "title1",
     space_key = "space1",
     parent_id = 1234,
+    toc = TRUE,
     update = TRUE,
     use_original_size = TRUE
   )
@@ -52,7 +54,7 @@ test_that("confluence_settings can be set from front-matter", {
   confl_upload_mock <- mockery::mock(NULL)
   do_confl_create_post_from_Rmd(confl_upload_mock, Rmd_with_all_defaults,
     title = "title2", space_key = "space2", parent_id = 9999,
-    update = FALSE, use_original_size = FALSE
+    toc = FALSE, update = FALSE, use_original_size = FALSE
   )
 
   expect_confluence_settings(
@@ -60,6 +62,7 @@ test_that("confluence_settings can be set from front-matter", {
     title = "title2",
     space_key = "space2",
     parent_id = 9999,
+    toc = FALSE,
     update = FALSE,
     use_original_size = FALSE
   )
@@ -71,6 +74,7 @@ confluence_settings:
   title: "title2"
   space_key: "space1"
   parent_id: 1234
+  toc: TRUE
   update: TRUE
   use_original_size: TRUE'
 
@@ -85,6 +89,7 @@ test_that("confluence_settings$title is prior to title", {
     title = "title2",
     space_key = "space1",
     parent_id = 1234,
+    toc = TRUE,
     update = TRUE,
     use_original_size = TRUE
   )
@@ -100,6 +105,7 @@ test_that("confluence_settings$title is prior to title", {
     title = "title3",
     space_key = "space1",
     parent_id = 1234,
+    toc = TRUE,
     update = TRUE,
     use_original_size = TRUE
   )
@@ -121,6 +127,7 @@ test_that("confluence_settings can be specified partially", {
     title = "title1",
     space_key = "space1",
     parent_id = NULL,
+    toc = FALSE, # toc must not be NULL
     update = NULL,
     use_original_size = FALSE # use_original_size must not be NULL
   )
@@ -144,6 +151,7 @@ test_that("confluence_settings raise an error when any of mandatory parameters a
     title = "title1",
     space_key = "space2",
     parent_id = NULL,
+    toc = FALSE, # toc must not be NULL
     update = NULL,
     use_original_size = FALSE # use_original_size must not be NULL
   )

--- a/tests/testthat/test-front-matter.R
+++ b/tests/testthat/test-front-matter.R
@@ -1,7 +1,3 @@
-should_not_be_called <- function(...) {
-  stop(deparse(match.call()[[1]]), "() should not be called", call. = FALSE)
-}
-
 do_confl_create_post_from_Rmd <- function(mock, text, ...) {
   tmp <- tempfile(fileext = ".Rmd")
   on.exit(unlink(tmp))

--- a/tests/testthat/test-toc.R
+++ b/tests/testthat/test-toc.R
@@ -1,0 +1,71 @@
+test_that("TOC is added when set via argument", {
+  tmp <- tempfile(fileext = ".Rmd")
+  on.exit(unlink(tmp))
+
+  writeLines(
+'---
+title: title1
+confluence_settings:
+  space_key: space1
+---
+
+# h1
+## h2
+', tmp)
+
+  mock <- mockery::mock(NULL)
+  with_mock(
+    "conflr::confl_list_pages" = function(...) list(size = 1, results = list(list(id = 1))),
+    "conflr::confl_list_attachments" = function(...) list(results = list()),
+    "conflr::confl_update_page" = mock,
+    "conflr::confl_get_current_user" = function(...) list(username = "user"),
+    "conflr:::try_get_personal_space_key" = should_not_be_called, {
+      confl_create_post_from_Rmd(tmp, interactive = FALSE, update = TRUE, toc = TRUE)
+    }
+  )
+
+  expect_equal(
+    mockery::mock_args(mock)[[1]]$body,
+    '<p><ac:structured-macro ac:name="toc" /></p>\n<h1>h1</h1>\n<h2>h2</h2>\n'
+  )
+})
+
+test_that("TOC is added when set via front-matter", {
+  tmp <- tempfile(fileext = ".Rmd")
+  on.exit(unlink(tmp))
+
+  writeLines(
+'---
+title: title1
+confluence_settings:
+  space_key: space1
+  toc: true
+---
+
+# h1
+## h2
+', tmp)
+
+  mock <- mockery::mock(NULL, cycle = TRUE)
+  with_mock(
+    "conflr::confl_list_pages" = function(...) list(size = 1, results = list(list(id = 1))),
+    "conflr::confl_list_attachments" = function(...) list(results = list()),
+    "conflr::confl_update_page" = mock,
+    "conflr::confl_get_current_user" = function(...) list(username = "user"),
+    "conflr:::try_get_personal_space_key" = should_not_be_called, {
+      confl_create_post_from_Rmd(tmp, interactive = FALSE, update = TRUE)
+      confl_create_post_from_Rmd(tmp, interactive = FALSE, update = TRUE, toc = FALSE)
+    }
+  )
+
+  expect_equal(
+    mockery::mock_args(mock)[[1]]$body,
+    '<p><ac:structured-macro ac:name="toc" /></p>\n<h1>h1</h1>\n<h2>h2</h2>\n'
+  )
+
+  expect_equal(
+    mockery::mock_args(mock)[[2]]$body,
+    '<h1>h1</h1>\n<h2>h2</h2>\n'
+  )
+})
+


### PR DESCRIPTION
Close #64 

### Example

`toc` can be set via front-matter

``` md
---
title: title1
confluence_settings:
  space_key: space1
  toc: true
---

# h1
## h2
```

or via argument of `confl_create_post_from_Rmd()`.

``` r
confl_create_post_from_Rmd(Rmd_file, interactive = FALSE, update = TRUE, toc = TRUE)
```