### PR TITLE
Support toc_depth

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,8 +25,9 @@
 * A new function `confl_contentbody_convert()` converts the Confluence-related
   formats by using the Confluence REST API (#58).
 
-* `confl_create_post_from_Rmd()` gets `toc` argument. When it's `TRUE`,
-  TOC is added at the top of the document (#64)
+* `confl_create_post_from_Rmd()` gets `toc` and `toc_depth` argument. When
+  `toc = TRUE`, TOC is added at the top of the document (#64). The depth of the
+  TOC can be specified via `toc_depth` argument (#67).
 
 # conflr 0.0.5
 

--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -10,7 +10,8 @@
 
 confl_upload <- function(title, space_key, type, parent_id, html_text,
                          imgs, imgs_realpath,
-                         toc = FALSE, update = NULL, use_original_size = FALSE,
+                         toc = FALSE, toc_depth = 7,
+                         update = NULL, use_original_size = FALSE,
                          interactive = NULL, session = NULL) {
   if (is.null(interactive)) {
     interactive <- interactive()
@@ -83,7 +84,16 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
   progress$set(message = "Uploading the document...")
 
   if (toc) {
-    html_text <- paste0('<p><ac:structured-macro ac:name="toc" /></p>\n', html_text)
+    html_text <- paste(
+      '<p>',
+      '  <ac:structured-macro ac:name="toc">',
+      glue::glue('    <ac:parameter ac:name="maxLevel">{toc_depth}</ac:parameter>'),
+      '  </ac:structured-macro>',
+      '</p>',
+      '',
+      html_text,
+      sep = "\n"
+    )
   }
 
   image_size_default <- if (!use_original_size) 600 else NULL

--- a/R/addin.R
+++ b/R/addin.R
@@ -22,6 +22,7 @@
 #' @param space_key The space key to find content under.
 #' @param parent_id The page ID of the parent pages.
 #' @param toc If `TRUE`, add TOC.
+#' @param toc_depth The depth of the TOC. Ignored when `toc` is `FALSE`.
 #' @param update If `TRUE`, overwrite the existing page (if it exists).
 #' @param use_original_size If `TRUE`, use the original image sizes.
 #'
@@ -44,6 +45,7 @@ confl_create_post_from_Rmd <- function(
   type = NULL,
   parent_id = NULL,
   toc = NULL,
+  toc_depth = NULL,
   update = NULL,
   use_original_size = NULL) {
 
@@ -109,6 +111,7 @@ confl_create_post_from_Rmd <- function(
     type = type,
     parent_id = parent_id,
     toc = toc,
+    toc_depth = toc_depth,
     update = update,
     use_original_size = use_original_size
   )
@@ -145,6 +148,7 @@ confl_create_post_from_Rmd <- function(
       imgs = imgs,
       imgs_realpath = imgs_realpath,
       toc = confluence_settings$toc %||% FALSE,
+      toc_depth = confluence_settings$toc_depth %||% 7,
       use_original_size = confluence_settings$use_original_size %||% FALSE
     )
 
@@ -163,6 +167,7 @@ confl_create_post_from_Rmd <- function(
       imgs = imgs,
       imgs_realpath = imgs_realpath,
       toc = confluence_settings$toc %||% FALSE,
+      toc_depth = confluence_settings$toc_depth %||% 7,
       update = confluence_settings$update,
       use_original_size = confluence_settings$use_original_size %||% FALSE,
       interactive = interactive
@@ -198,6 +203,7 @@ confl_upload_interactively <- function(title, space_key, type, parent_id, html_t
     imgs = imgs,
     imgs_realpath = imgs_realpath,
     toc = toc,
+    toc_depth = toc_depth,
     use_original_size = use_original_size
   )
 
@@ -220,6 +226,7 @@ confl_upload_interactively <- function(title, space_key, type, parent_id, html_t
         imgs = imgs,
         imgs_realpath = imgs_realpath,
         toc = input$toc,
+        toc_depth = input$toc_depth,
         use_original_size = input$use_original_size
       )
     })
@@ -260,7 +267,8 @@ wrap_with_column <- function(..., width = 2) {
 
 confl_addin_ui <- function(title, space_key, type, parent_id, html_text,
                            imgs, imgs_realpath,
-                           toc = FALSE, use_original_size = FALSE) {
+                           toc = FALSE, toc_depth = 7,
+                           use_original_size = FALSE) {
   # title bar
   title_bar_button <- miniUI::miniTitleBarButton("done", "Publish", primary = TRUE)
   title_bar <- miniUI::gadgetTitleBar("Preview", right = title_bar_button)
@@ -279,6 +287,7 @@ confl_addin_ui <- function(title, space_key, type, parent_id, html_text,
 
   # add TOC or not
   toc_input <- shiny::checkboxInput(inputId = "toc", label = "TOC", value = toc)
+  toc_depth_input <- shiny::numericInput(inputId = "toc_depth", label = "TOC depth", value = toc_depth)
 
   # Preview
   html_text_for_preview <- embed_images(html_text, imgs, imgs_realpath)
@@ -291,7 +300,7 @@ confl_addin_ui <- function(title, space_key, type, parent_id, html_text,
         wrap_with_column(type_input),
         wrap_with_column(space_key_input),
         wrap_with_column(parent_id_input),
-        wrap_with_column(use_original_size_input, toc_input, width = 4)
+        wrap_with_column(use_original_size_input, toc_input, toc_depth_input, width = 4)
       ),
       shiny::hr(),
       shiny::h1(title, align = "center"),

--- a/R/addin.R
+++ b/R/addin.R
@@ -27,7 +27,7 @@
 #' @param use_original_size If `TRUE`, use the original image sizes.
 #'
 #' @details
-#' `title`, `type`, `space_key`, `parent_id`, `toc`, `update`, and
+#' `title`, `type`, `space_key`, `parent_id`, `toc`, `toc_depth`, `update`, and
 #' `use_original_size` can be specified as `confluence_settings` item in the
 #' front-matter of the Rmd file to knit. The arguments of
 #' `confl_create_post_from_Rmd()` overwrite these settings if provided.
@@ -191,7 +191,8 @@ confl_create_post_from_Rmd_addin <- function() {
 
 confl_upload_interactively <- function(title, space_key, type, parent_id, html_text,
                                        imgs, imgs_realpath,
-                                       toc = FALSE, use_original_size = FALSE) {
+                                       toc = FALSE, toc_depth = 7,
+                                       use_original_size = FALSE) {
 
   # Shiny UI -----------------------------------------------------------
   ui <- confl_addin_ui(

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -49,7 +49,7 @@ params in the YAML front-matter.}
 Knit and post a given R Markdown file to 'Confluence'.
 }
 \details{
-\code{title}, \code{type}, \code{space_key}, \code{parent_id}, \code{toc}, \code{update}, and
+\code{title}, \code{type}, \code{space_key}, \code{parent_id}, \code{toc}, \code{toc_depth}, \code{update}, and
 \code{use_original_size} can be specified as \code{confluence_settings} item in the
 front-matter of the Rmd file to knit. The arguments of
 \code{confl_create_post_from_Rmd()} overwrite these settings if provided.

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -14,6 +14,7 @@ confl_create_post_from_Rmd(
   type = NULL,
   parent_id = NULL,
   toc = NULL,
+  toc_depth = NULL,
   update = NULL,
   use_original_size = NULL
 )
@@ -37,6 +38,8 @@ params in the YAML front-matter.}
 \item{parent_id}{The page ID of the parent pages.}
 
 \item{toc}{If \code{TRUE}, add TOC.}
+
+\item{toc_depth}{The depth of the TOC. Ignored when \code{toc} is \code{FALSE}.}
 
 \item{update}{If \code{TRUE}, overwrite the existing page (if it exists).}
 

--- a/tests/testthat/test-front-matter.R
+++ b/tests/testthat/test-front-matter.R
@@ -27,6 +27,7 @@ confluence_settings:
   space_key: "space1"
   parent_id: 1234
   toc: TRUE
+  toc_depth: 4
   update: TRUE
   use_original_size: TRUE'
 
@@ -42,6 +43,7 @@ test_that("confluence_settings can be set from front-matter", {
     space_key = "space1",
     parent_id = 1234,
     toc = TRUE,
+    toc_depth = 4,
     update = TRUE,
     use_original_size = TRUE
   )
@@ -50,7 +52,7 @@ test_that("confluence_settings can be set from front-matter", {
   confl_upload_mock <- mockery::mock(NULL)
   do_confl_create_post_from_Rmd(confl_upload_mock, Rmd_with_all_defaults,
     title = "title2", space_key = "space2", parent_id = 9999,
-    toc = FALSE, update = FALSE, use_original_size = FALSE
+    toc = FALSE, toc_depth = 2, update = FALSE, use_original_size = FALSE
   )
 
   expect_confluence_settings(
@@ -59,6 +61,7 @@ test_that("confluence_settings can be set from front-matter", {
     space_key = "space2",
     parent_id = 9999,
     toc = FALSE,
+    toc_depth = 2,
     update = FALSE,
     use_original_size = FALSE
   )
@@ -71,6 +74,7 @@ confluence_settings:
   space_key: "space1"
   parent_id: 1234
   toc: TRUE
+  toc_depth: 4
   update: TRUE
   use_original_size: TRUE'
 
@@ -86,6 +90,7 @@ test_that("confluence_settings$title is prior to title", {
     space_key = "space1",
     parent_id = 1234,
     toc = TRUE,
+    toc_depth = 4,
     update = TRUE,
     use_original_size = TRUE
   )
@@ -102,6 +107,7 @@ test_that("confluence_settings$title is prior to title", {
     space_key = "space1",
     parent_id = 1234,
     toc = TRUE,
+    toc_depth = 4,
     update = TRUE,
     use_original_size = TRUE
   )
@@ -124,6 +130,7 @@ test_that("confluence_settings can be specified partially", {
     space_key = "space1",
     parent_id = NULL,
     toc = FALSE, # toc must not be NULL
+    toc_depth = 7,
     update = NULL,
     use_original_size = FALSE # use_original_size must not be NULL
   )
@@ -148,6 +155,7 @@ test_that("confluence_settings raise an error when any of mandatory parameters a
     space_key = "space2",
     parent_id = NULL,
     toc = FALSE, # toc must not be NULL
+    toc_depth = 7,
     update = NULL,
     use_original_size = FALSE # use_original_size must not be NULL
   )

--- a/tests/testthat/test-toc.R
+++ b/tests/testthat/test-toc.R
@@ -26,7 +26,15 @@ confluence_settings:
 
   expect_equal(
     mockery::mock_args(mock)[[1]]$body,
-    '<p><ac:structured-macro ac:name="toc" /></p>\n<h1>h1</h1>\n<h2>h2</h2>\n'
+'<p>
+  <ac:structured-macro ac:name="toc">
+    <ac:parameter ac:name="maxLevel">7</ac:parameter>
+  </ac:structured-macro>
+</p>
+
+<h1>h1</h1>
+<h2>h2</h2>
+'
   )
 })
 
@@ -40,6 +48,7 @@ title: title1
 confluence_settings:
   space_key: space1
   toc: true
+  toc_depth: 3
 ---
 
 # h1
@@ -60,7 +69,15 @@ confluence_settings:
 
   expect_equal(
     mockery::mock_args(mock)[[1]]$body,
-    '<p><ac:structured-macro ac:name="toc" /></p>\n<h1>h1</h1>\n<h2>h2</h2>\n'
+'<p>
+  <ac:structured-macro ac:name="toc">
+    <ac:parameter ac:name="maxLevel">3</ac:parameter>
+  </ac:structured-macro>
+</p>
+
+<h1>h1</h1>
+<h2>h2</h2>
+'
   )
 
   expect_equal(


### PR DESCRIPTION
Fix #67 

The `toc_depth` can be specified via `maxLevel` parameter whose default is `7` c.f. https://confluence.atlassian.com/doc/table-of-contents-macro-182682099.html