### PR TITLE
Expose supported_syntax_highlighting

### DIFF
--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -11,6 +11,7 @@
 confl_upload <- function(title, space_key, type, parent_id, html_text,
                          imgs, imgs_realpath,
                          toc = FALSE, toc_depth = 7,
+                         supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
                          update = NULL, use_original_size = FALSE,
                          interactive = NULL, session = NULL) {
   if (is.null(interactive)) {
@@ -101,7 +102,8 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
     id = id,
     title = title,
     body = html_text,
-    image_size_default = image_size_default
+    image_size_default = image_size_default,
+    supported_syntax_highlighting = supported_syntax_highlighting
   )
   results_url <- paste0(result$`_links`$base, result$`_links`$webui)
 

--- a/R/addin.R
+++ b/R/addin.R
@@ -274,6 +274,9 @@ wrap_with_column <- function(..., width = 2) {
   shiny::column(width = width, ...)
 }
 
+# NOTE: conflr_supported_syntax_highlighting cannot be set via GUI because
+#       it's not a feature frequently used and is a bit difficult to input
+#       via Shiny interface.
 confl_addin_ui <- function(title, space_key, type, parent_id, html_text,
                            imgs, imgs_realpath,
                            toc = FALSE, toc_depth = 7,

--- a/R/addin.R
+++ b/R/addin.R
@@ -26,6 +26,8 @@
 #' @param update If `TRUE`, overwrite the existing page (if it exists).
 #' @param use_original_size If `TRUE`, use the original image sizes.
 #'
+#' @inheritParams confl_content
+#'
 #' @details
 #' `title`, `type`, `space_key`, `parent_id`, `toc`, `toc_depth`, `update`, and
 #' `use_original_size` can be specified as `confluence_settings` item in the
@@ -46,6 +48,7 @@ confl_create_post_from_Rmd <- function(
   parent_id = NULL,
   toc = NULL,
   toc_depth = NULL,
+  supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
   update = NULL,
   use_original_size = NULL) {
 
@@ -112,6 +115,7 @@ confl_create_post_from_Rmd <- function(
     parent_id = parent_id,
     toc = toc,
     toc_depth = toc_depth,
+    supported_syntax_highlighting = supported_syntax_highlighting,
     update = update,
     use_original_size = use_original_size
   )
@@ -149,6 +153,7 @@ confl_create_post_from_Rmd <- function(
       imgs_realpath = imgs_realpath,
       toc = confluence_settings$toc %||% FALSE,
       toc_depth = confluence_settings$toc_depth %||% 7,
+      supported_syntax_highlighting = confluence_settings$supported_syntax_highlighting,
       use_original_size = confluence_settings$use_original_size %||% FALSE
     )
 
@@ -168,6 +173,7 @@ confl_create_post_from_Rmd <- function(
       imgs_realpath = imgs_realpath,
       toc = confluence_settings$toc %||% FALSE,
       toc_depth = confluence_settings$toc_depth %||% 7,
+      supported_syntax_highlighting = confluence_settings$supported_syntax_highlighting,
       update = confluence_settings$update,
       use_original_size = confluence_settings$use_original_size %||% FALSE,
       interactive = interactive
@@ -192,6 +198,7 @@ confl_create_post_from_Rmd_addin <- function() {
 confl_upload_interactively <- function(title, space_key, type, parent_id, html_text,
                                        imgs, imgs_realpath,
                                        toc = FALSE, toc_depth = 7,
+                                       supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
                                        use_original_size = FALSE) {
 
   # Shiny UI -----------------------------------------------------------
@@ -228,6 +235,7 @@ confl_upload_interactively <- function(title, space_key, type, parent_id, html_t
         imgs_realpath = imgs_realpath,
         toc = input$toc,
         toc_depth = input$toc_depth,
+        supported_syntax_highlighting = supported_syntax_highlighting,
         use_original_size = input$use_original_size
       )
     })

--- a/R/translate.R
+++ b/R/translate.R
@@ -19,12 +19,33 @@ supported_syntax_highlighting_default <- c(
   yaml = "yaml"
 )
 
-translate_to_confl_macro <- function(html_text, image_size_default = 600, supported_syntax_highlighting = character(0)) {
-  # if supported_syntax_highlighting is provided as unnamed form, name it
-  if (!is.null(supported_syntax_highlighting) && is.null(names(supported_syntax_highlighting))) {
-    names(supported_syntax_highlighting) <- supported_syntax_highlighting
+normalise_supported_syntax_highlighting <- function(x) {
+  # supported_syntax_highlighting can be
+  # 1) a named character vector
+  # 2) an unnamed character vector
+  # 3) a named list of characters
+  # 4) an unnamed list of characters
+  # 5) NULL
+
+  if (is.null(x)) {
+    return(NULL)
   }
 
+  # if supported_syntax_highlighting is a list, flatten it (TODO: use vctrs?)
+  if (is.list(x)) {
+    x <- unlist(x, recursive = FALSE)
+  }
+
+  # if supported_syntax_highlighting is provided as unnamed form, name it
+  if (is.character(x) && is.null(names(x))) {
+    names(x) <- x
+  }
+
+  x
+}
+
+translate_to_confl_macro <- function(html_text, image_size_default = 600, supported_syntax_highlighting = NULL) {
+  supported_syntax_highlighting <- normalise_supported_syntax_highlighting(supported_syntax_highlighting)
   supported_syntax_highlighting <- c(supported_syntax_highlighting, supported_syntax_highlighting_default)
 
   html_text <- paste0("<body>", html_text, "</body>")

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -15,6 +15,7 @@ confl_create_post_from_Rmd(
   parent_id = NULL,
   toc = NULL,
   toc_depth = NULL,
+  supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
   update = NULL,
   use_original_size = NULL
 )
@@ -40,6 +41,8 @@ params in the YAML front-matter.}
 \item{toc}{If \code{TRUE}, add TOC.}
 
 \item{toc_depth}{The depth of the TOC. Ignored when \code{toc} is \code{FALSE}.}
+
+\item{supported_syntax_highlighting}{A named character vector of supported syntax highlighting other than default (e.g. \code{c(r = "r")}).}
 
 \item{update}{If \code{TRUE}, overwrite the existing page (if it exists).}
 

--- a/tests/testthat/test-front-matter.R
+++ b/tests/testthat/test-front-matter.R
@@ -28,6 +28,9 @@ confluence_settings:
   parent_id: 1234
   toc: TRUE
   toc_depth: 4
+  supported_syntax_highlighting:
+    r: r
+    foo: bar
   update: TRUE
   use_original_size: TRUE'
 
@@ -44,6 +47,7 @@ test_that("confluence_settings can be set from front-matter", {
     parent_id = 1234,
     toc = TRUE,
     toc_depth = 4,
+    supported_syntax_highlighting = list(r = "r", foo = "bar"),
     update = TRUE,
     use_original_size = TRUE
   )
@@ -52,7 +56,8 @@ test_that("confluence_settings can be set from front-matter", {
   confl_upload_mock <- mockery::mock(NULL)
   do_confl_create_post_from_Rmd(confl_upload_mock, Rmd_with_all_defaults,
     title = "title2", space_key = "space2", parent_id = 9999,
-    toc = FALSE, toc_depth = 2, update = FALSE, use_original_size = FALSE
+    toc = FALSE, toc_depth = 2, supported_syntax_highlighting = c(two_plus_two = "five"),
+     update = FALSE, use_original_size = FALSE
   )
 
   expect_confluence_settings(
@@ -62,6 +67,7 @@ test_that("confluence_settings can be set from front-matter", {
     parent_id = 9999,
     toc = FALSE,
     toc_depth = 2,
+    supported_syntax_highlighting = c(two_plus_two = "five"),
     update = FALSE,
     use_original_size = FALSE
   )
@@ -75,6 +81,9 @@ confluence_settings:
   parent_id: 1234
   toc: TRUE
   toc_depth: 4
+  supported_syntax_highlighting:
+    r: r
+    foo: bar
   update: TRUE
   use_original_size: TRUE'
 
@@ -91,6 +100,7 @@ test_that("confluence_settings$title is prior to title", {
     parent_id = 1234,
     toc = TRUE,
     toc_depth = 4,
+    supported_syntax_highlighting = list(r = "r", foo = "bar"),
     update = TRUE,
     use_original_size = TRUE
   )
@@ -108,6 +118,7 @@ test_that("confluence_settings$title is prior to title", {
     parent_id = 1234,
     toc = TRUE,
     toc_depth = 4,
+    supported_syntax_highlighting = list(r = "r", foo = "bar"),
     update = TRUE,
     use_original_size = TRUE
   )
@@ -131,10 +142,28 @@ test_that("confluence_settings can be specified partially", {
     parent_id = NULL,
     toc = FALSE, # toc must not be NULL
     toc_depth = 7,
+    supported_syntax_highlighting = NULL,
     update = NULL,
     use_original_size = FALSE # use_original_size must not be NULL
   )
 })
+
+test_that("supported_syntax_highlighting can be set via option", {
+
+  # case: confluence_settings$title is prior to title
+  confl_upload_mock <- mockery::mock(NULL)
+
+  withr::with_options(
+    list(conflr_supported_syntax_highlighting = "r"),
+    do_confl_create_post_from_Rmd(confl_upload_mock, Rmd_with_some_settings)
+  )
+
+  expect_confluence_settings(
+    confl_upload_mock,
+    supported_syntax_highlighting = "r"
+  )
+})
+
 
 Rmd_without_space_key <- 'title: "title1"'
 
@@ -156,6 +185,7 @@ test_that("confluence_settings raise an error when any of mandatory parameters a
     parent_id = NULL,
     toc = FALSE, # toc must not be NULL
     toc_depth = 7,
+    supported_syntax_highlighting = NULL,
     update = NULL,
     use_original_size = FALSE # use_original_size must not be NULL
   )

--- a/tests/testthat/test-front-matter.R
+++ b/tests/testthat/test-front-matter.R
@@ -26,13 +26,13 @@ Rmd_with_all_defaults <-
 confluence_settings:
   space_key: "space1"
   parent_id: 1234
-  toc: TRUE
+  toc: true
   toc_depth: 4
   supported_syntax_highlighting:
     r: r
     foo: bar
-  update: TRUE
-  use_original_size: TRUE'
+  update: true
+  use_original_size: true'
 
 test_that("confluence_settings can be set from front-matter", {
 
@@ -84,8 +84,8 @@ confluence_settings:
   supported_syntax_highlighting:
     r: r
     foo: bar
-  update: TRUE
-  use_original_size: TRUE'
+  update: true
+  use_original_size: true'
 
 test_that("confluence_settings$title is prior to title", {
 

--- a/tests/testthat/test-front-matter.R
+++ b/tests/testthat/test-front-matter.R
@@ -57,7 +57,7 @@ test_that("confluence_settings can be set from front-matter", {
   do_confl_create_post_from_Rmd(confl_upload_mock, Rmd_with_all_defaults,
     title = "title2", space_key = "space2", parent_id = 9999,
     toc = FALSE, toc_depth = 2, supported_syntax_highlighting = c(two_plus_two = "five"),
-     update = FALSE, use_original_size = FALSE
+    update = FALSE, use_original_size = FALSE
   )
 
   expect_confluence_settings(

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -180,6 +180,14 @@ test_that("replace_image() works", {
   )
 })
 
+test_that("normalise_supported_syntax_highlighting() works", {
+  expect_equal(normalise_supported_syntax_highlighting(NULL), NULL)
+  expect_equal(normalise_supported_syntax_highlighting("r"), c(r = "r"))
+  expect_equal(normalise_supported_syntax_highlighting(c(foo = "bar")), c(foo = "bar"))
+  expect_equal(normalise_supported_syntax_highlighting(list("r")), c(r = "r"))
+  expect_equal(normalise_supported_syntax_highlighting(list(foo = "bar")), c(foo = "bar"))
+})
+
 test_that("translate_to_confl_macro() works", {
   # code chunk
   html_text <- commonmark::markdown_html(


### PR DESCRIPTION
Fix #54 

The implementation is almost done in #55. This PR exposes the parameter to users. `supported_syntax_highlighting` can be set either via a parameter of front-matter, 

``` yaml
title: "title1"
confluence_settings:
  space_key: "space1"
  supported_syntax_highlighting:
  - r
```

or via an argument,

``` r
confl_create_post_from_Rmd(
  Rmd_file, interactive = FALSE, update = TRUE,
  supported_syntax_highlighting = "r"
)
```

or via an option.

``` r
options(conflr_supported_syntax_highlighting = "r")
```