### PR TITLE
Bypass conversion of <ac:...> and <ri:...>

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,13 @@
   `toc = TRUE`, TOC is added at the top of the document (#64). The depth of the
   TOC can be specified via `toc_depth` argument (#67).
 
+* `confl_post_page()` and `confl_update_page()` no longer translate the
+  Confluence macros automatically. Accordingly, they lose `image_size_default`
+  and `supported_syntax_highlighting` arguments (#76).
+
+* `confl_create_post_from_Rmd()` now handles documents containing Confluence
+  macro tags (i.e. `<ac:...>` or `<ri:...>`) properly (#76).
+
 # conflr 0.0.5
 
 * Initial release on GitHub

--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -96,13 +96,16 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
     )
   }
 
-  image_size_default <- if (!use_original_size) 600 else NULL
+  html_text <- translate_to_confl_macro(
+    html_text,
+    image_size_default = if (!use_original_size) 600 else NULL,
+    supported_syntax_highlighting = supported_syntax_highlighting
+  )
+
   result <- confl_update_page(
     id = id,
     title = title,
-    body = html_text,
-    image_size_default = image_size_default,
-    supported_syntax_highlighting = supported_syntax_highlighting
+    body = html_text
   )
   results_url <- paste0(result$`_links`$base, result$`_links`$webui)
 

--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -84,16 +84,18 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
   progress$set(message = "Uploading the document...")
 
   if (toc) {
-    html_text <- paste(
+    toc_html <- paste(
       '<p>',
       '  <ac:structured-macro ac:name="toc">',
       glue::glue('    <ac:parameter ac:name="maxLevel">{toc_depth}</ac:parameter>'),
       '  </ac:structured-macro>',
       '</p>',
-      '',
-      html_text,
       sep = "\n"
     )
+
+    # html_text is already replaced <ac:...> and <ri:...>
+    toc_html <- mark_confluence_namespaces(toc_html)
+    html_text <- paste(toc_html, html_text, sep = "\n")
   }
 
   html_text <- translate_to_confl_macro(
@@ -101,6 +103,9 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
     image_size_default = if (!use_original_size) 600 else NULL,
     supported_syntax_highlighting = supported_syntax_highlighting
   )
+
+  # Restore <ac:...> and <ri:...> tags before actually posting to Confluence
+  html_text <- restore_confluence_namespaces(html_text)
 
   result <- confl_update_page(
     id = id,

--- a/R/addin.R
+++ b/R/addin.R
@@ -29,8 +29,6 @@
 #' @param supported_syntax_highlighting
 #'   A named character vector of supported syntax highlighting other than default (e.g. `c(r = "r")`).
 #'
-#' @inheritParams confl_content
-#'
 #' @details
 #' `title`, `type`, `space_key`, `parent_id`, `toc`, `toc_depth`, `update`, and
 #' `use_original_size` can be specified as `confluence_settings` item in the

--- a/R/addin.R
+++ b/R/addin.R
@@ -24,8 +24,8 @@
 #' @param toc If `TRUE`, add TOC.
 #' @param toc_depth The depth of the TOC. Ignored when `toc` is `FALSE`.
 #' @param update If `TRUE`, overwrite the existing page (if it exists).
-#' @param image_size_default
-#'   The default width of images in pixel. If `NULL`, images are displayed in their original sizes.
+#' @param use_original_size
+#'   If `TRUE`, use the original image sizes.
 #' @param supported_syntax_highlighting
 #'   A named character vector of supported syntax highlighting other than default (e.g. `c(r = "r")`).
 #'

--- a/R/addin.R
+++ b/R/addin.R
@@ -24,7 +24,10 @@
 #' @param toc If `TRUE`, add TOC.
 #' @param toc_depth The depth of the TOC. Ignored when `toc` is `FALSE`.
 #' @param update If `TRUE`, overwrite the existing page (if it exists).
-#' @param use_original_size If `TRUE`, use the original image sizes.
+#' @param image_size_default
+#'   The default width of images in pixel. If `NULL`, images are displayed in their original sizes.
+#' @param supported_syntax_highlighting
+#'   A named character vector of supported syntax highlighting other than default (e.g. `c(r = "r")`).
 #'
 #' @inheritParams confl_content
 #'
@@ -132,6 +135,9 @@ confl_create_post_from_Rmd <- function(
 
   # conflr doesn't insert a title in the content automatically
   md_text <- read_utf8(md_file)
+  # replace ac: and ri: namespaces to bypass the conversion
+  md_text <- mark_confluence_namespaces(md_text)
+
   html_text <- commonmark::markdown_html(md_text)
 
   md_dir <- dirname(md_file)

--- a/R/addin.R
+++ b/R/addin.R
@@ -135,7 +135,11 @@ confl_create_post_from_Rmd <- function(
 
   # conflr doesn't insert a title in the content automatically
   md_text <- read_utf8(md_file)
-  # replace ac: and ri: namespaces to bypass the conversion
+
+  # Replace <ac:...> and <ri:...> because they are not recognized as proper tags
+  # by commonmark and accordingly get escaped. We need to replace the namespace
+  # to bypass the unwanted conversions. The tags will be restored later in
+  # confl_upload().
   md_text <- mark_confluence_namespaces(md_text)
 
   html_text <- commonmark::markdown_html(md_text)

--- a/R/content.R
+++ b/R/content.R
@@ -58,22 +58,13 @@ confl_get_page <- function(id, expand = "body.storage") {
 #'   The HTML source of the page.
 #' @param ancestors
 #'   The page ID of the parent pages.
-#' @param image_size_default
-#'   The default width of images in pixel. If `NULL`, images are displayed in their original sizes.
-#' @param supported_syntax_highlighting
-#'   A named character vector of supported syntax highlighting other than default (e.g. `c(r = "r")`).
 #' @export
 confl_post_page <- function(type = c("page", "blogpost"),
                             spaceKey,
                             title,
                             body,
-                            ancestors = NULL,
-                            image_size_default = 600,
-                            supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting")) {
+                            ancestors = NULL) {
   type <- arg_match(type)
-
-  body <- translate_to_confl_macro(body, image_size_default = image_size_default,
-                                   supported_syntax_highlighting = supported_syntax_highlighting)
 
   req_body <- list(
     type = type,
@@ -96,14 +87,9 @@ confl_post_page <- function(type = c("page", "blogpost"),
 #' @export
 confl_update_page <- function(id,
                               title,
-                              body,
-                              image_size_default = 600,
-                              supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting")) {
+                              body) {
   id <- as.character(id)
   page_info <- confl_get_page(id, expand = "version")
-
-  body <- translate_to_confl_macro(body, image_size_default = image_size_default,
-                                   supported_syntax_highlighting = supported_syntax_highlighting)
 
   res <- confl_verb("PUT", glue::glue("/content/{id}"),
     body = list(

--- a/R/translate.R
+++ b/R/translate.R
@@ -250,9 +250,37 @@ replace_image <- function(x, image_size_default = 600) {
 }
 
 mark_confluence_namespaces <- function(x) {
+  locs <- stringi::stri_locate_all_regex(
+    x,
+    "</?(ac|ri):[^<>]*?>",
+    omit_no_match = TRUE
+  )[[1]]
 
+  for (loc in rev(split(locs, row(locs)))) {
+    orig <- stringi::stri_sub(x, loc[1], loc[2])
+    marked <- stringi::stri_replace_all_regex(orig,
+                                              pattern = "(?<=<|\\s|^)(/?)(ac|ri):",
+                                              replacement = "$1confl-$2-")
+    stringi::stri_sub(x, loc[1], loc[2]) <- marked
+  }
+
+  x
 }
 
 restore_confluence_namespaces <- function(x) {
+  locs <- stringi::stri_locate_all_regex(
+    x,
+    "</?confl-(ac|ri)-[^<>]*?>",
+    omit_no_match = TRUE
+  )[[1]]
+
+  for (loc in rev(split(locs, row(locs)))) {
+    orig <- stringi::stri_sub(x, loc[1], loc[2])
+    restored <- stringi::stri_replace_all_regex(orig,
+                                                pattern = "(?<=<|\\s|^)(/?)confl-(ac|ri)-",
+                                                replacement = "$1$2:")
+    stringi::stri_sub(x, loc[1], loc[2]) <- restored
+  }
+
   x
 }

--- a/R/translate.R
+++ b/R/translate.R
@@ -249,10 +249,10 @@ replace_image <- function(x, image_size_default = 600) {
   x
 }
 
-escape_confluence_namespaces <- function(x) {
-  x
+mark_confluence_namespaces <- function(x) {
+
 }
 
-unescape_confluence_namespaces <- function(x) {
+restore_confluence_namespaces <- function(x) {
   x
 }

--- a/R/translate.R
+++ b/R/translate.R
@@ -248,3 +248,11 @@ replace_image <- function(x, image_size_default = 600) {
   }
   x
 }
+
+escape_confluence_namespaces <- function(x) {
+  x
+}
+
+unescape_confluence_namespaces <- function(x) {
+  x
+}

--- a/man/confl_content.Rd
+++ b/man/confl_content.Rd
@@ -25,18 +25,10 @@ confl_post_page(
   spaceKey,
   title,
   body,
-  ancestors = NULL,
-  image_size_default = 600,
-  supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting")
+  ancestors = NULL
 )
 
-confl_update_page(
-  id,
-  title,
-  body,
-  image_size_default = 600,
-  supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting")
-)
+confl_update_page(id, title, body)
 
 confl_delete_page(id)
 }
@@ -59,10 +51,6 @@ contents, use periods. (e.g. \verb{body.storage,history}).}
 \item{body}{The HTML source of the page.}
 
 \item{ancestors}{The page ID of the parent pages.}
-
-\item{image_size_default}{The default width of images in pixel. If \code{NULL}, images are displayed in their original sizes.}
-
-\item{supported_syntax_highlighting}{A named character vector of supported syntax highlighting other than default (e.g. \code{c(r = "r")}).}
 }
 \description{
 REST Wrapper for the ContentService

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -46,7 +46,7 @@ params in the YAML front-matter.}
 
 \item{update}{If \code{TRUE}, overwrite the existing page (if it exists).}
 
-\item{use_original_size}{If \code{TRUE}, use the original image sizes.}
+\item{image_size_default}{The default width of images in pixel. If \code{NULL}, images are displayed in their original sizes.}
 }
 \description{
 Knit and post a given R Markdown file to 'Confluence'.

--- a/man/confl_create_post_from_Rmd.Rd
+++ b/man/confl_create_post_from_Rmd.Rd
@@ -46,7 +46,7 @@ params in the YAML front-matter.}
 
 \item{update}{If \code{TRUE}, overwrite the existing page (if it exists).}
 
-\item{image_size_default}{The default width of images in pixel. If \code{NULL}, images are displayed in their original sizes.}
+\item{use_original_size}{If \code{TRUE}, use the original image sizes.}
 }
 \description{
 Knit and post a given R Markdown file to 'Confluence'.

--- a/tests/testthat/test-toc.R
+++ b/tests/testthat/test-toc.R
@@ -31,10 +31,8 @@ confluence_settings:
     <ac:parameter ac:name="maxLevel">7</ac:parameter>
   </ac:structured-macro>
 </p>
-
 <h1>h1</h1>
-<h2>h2</h2>
-'
+<h2>h2</h2>'
   )
 })
 
@@ -74,15 +72,13 @@ confluence_settings:
     <ac:parameter ac:name="maxLevel">3</ac:parameter>
   </ac:structured-macro>
 </p>
-
 <h1>h1</h1>
-<h2>h2</h2>
-'
+<h2>h2</h2>'
   )
 
   expect_equal(
     mockery::mock_args(mock)[[2]]$body,
-    '<h1>h1</h1>\n<h2>h2</h2>\n'
+    '<h1>h1</h1>\n<h2>h2</h2>'
   )
 })
 

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -272,6 +272,10 @@ test_that("mark_confluence_namespaces() works", {
     '<confl-ac-foo confl-ac-bar="baz">'
   )
   expect_equal(
+    mark_confluence_namespaces('<ac:foo\nac:bar="baz">'),
+    '<confl-ac-foo\nconfl-ac-bar="baz">'
+  )
+  expect_equal(
     mark_confluence_namespaces('<ac:image><ri:attachment ri:filename="1.png" /></ac:image>'),
     '<confl-ac-image><confl-ri-attachment confl-ri-filename="1.png" /></confl-ac-image>'
   )
@@ -284,6 +288,10 @@ test_that("restore_confluence_namespaces() works", {
   expect_equal(
     restore_confluence_namespaces('<confl-ac-foo confl-ac-bar="baz">'),
     '<ac:foo ac:bar="baz">'
+  )
+  expect_equal(
+    restore_confluence_namespaces('<confl-ac-foo\nconfl-ac-bar="baz">'),
+    '<ac:foo\nac:bar="baz">'
   )
   expect_equal(
     restore_confluence_namespaces('<confl-ac-image><confl-ri-attachment confl-ri-filename="1.png" /></confl-ac-image>'),

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -266,30 +266,30 @@ $$"
 })
 
 
-test_that("escape_confluence_namespaces() works", {
+test_that("mark_confluence_namespaces() works", {
   expect_equal(
-    escape_confluence_namespaces('<ac:foo ac:bar="baz">'),
+    mark_confluence_namespaces('<ac:foo ac:bar="baz">'),
     '<confl-ac-foo confl-ac-bar="baz">'
   )
   expect_equal(
-    escape_confluence_namespaces('<ac:image><ri:attachment ri:filename="1.png" /></ac:image>'),
+    mark_confluence_namespaces('<ac:image><ri:attachment ri:filename="1.png" /></ac:image>'),
     '<confl-ac-image><confl-ri-attachment confl-ri-filename="1.png" /></confl-ac-image>'
   )
 
   # do not convert ac: outside of the tags
-  expect_equal(escape_confluence_namespaces('<p>ac:</p>'), '<p>ac:</p>')
+  expect_equal(mark_confluence_namespaces('<p>ac:</p>'), '<p>ac:</p>')
 })
 
-test_that("unescape_confluence_namespaces() works", {
+test_that("restore_confluence_namespaces() works", {
   expect_equal(
-    escape_confluence_namespaces('<confl-ac-foo confl-ac-bar="baz">'),
+    restore_confluence_namespaces('<confl-ac-foo confl-ac-bar="baz">'),
     '<ac:foo ac:bar="baz">'
   )
   expect_equal(
-    escape_confluence_namespaces('<confl-ac-image><confl-ri-attachment confl-ri-filename="1.png" /></confl-ac-image>'),
+    restore_confluence_namespaces('<confl-ac-image><confl-ri-attachment confl-ri-filename="1.png" /></confl-ac-image>'),
     '<ac:image><ri:attachment ri:filename="1.png" /></ac:image>'
   )
 
   # do not convert cobfl-ac- outside of the tags
-  expect_equal(escape_confluence_namespaces('<p>confl-ac-</p>'), '<p>confl-ac-</p>')
+  expect_equal(restore_confluence_namespaces('<p>confl-ac-</p>'), '<p>confl-ac-</p>')
 })

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -264,3 +264,32 @@ $$"
 </ac:structured-macro></p>'
   )
 })
+
+
+test_that("escape_confluence_namespaces() works", {
+  expect_equal(
+    escape_confluence_namespaces('<ac:foo ac:bar="baz">'),
+    '<confl-ac-foo confl-ac-bar="baz">'
+  )
+  expect_equal(
+    escape_confluence_namespaces('<ac:image><ri:attachment ri:filename="1.png" /></ac:image>'),
+    '<confl-ac-image><confl-ri-attachment confl-ri-filename="1.png" /></confl-ac-image>'
+  )
+
+  # do not convert ac: outside of the tags
+  expect_equal(escape_confluence_namespaces('<p>ac:</p>'), '<p>ac:</p>')
+})
+
+test_that("unescape_confluence_namespaces() works", {
+  expect_equal(
+    escape_confluence_namespaces('<confl-ac-foo confl-ac-bar="baz">'),
+    '<ac:foo ac:bar="baz">'
+  )
+  expect_equal(
+    escape_confluence_namespaces('<confl-ac-image><confl-ri-attachment confl-ri-filename="1.png" /></confl-ac-image>'),
+    '<ac:image><ri:attachment ri:filename="1.png" /></ac:image>'
+  )
+
+  # do not convert cobfl-ac- outside of the tags
+  expect_equal(escape_confluence_namespaces('<p>confl-ac-</p>'), '<p>confl-ac-</p>')
+})


### PR DESCRIPTION
Fix #65 

* Replace `ac:` namespace with `confl-ac-` so that it can avoid getting escaped by `commonmark::markdown_html()`
* To make the implementation simple, do `translate_to_confl_macro()` outside of `confl_(update|post)_page()`.