### PR TITLE
Set opts_chunk in confluence_document() for consistency

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -49,15 +49,6 @@ confl_create_post_from_Rmd <- function(Rmd_file, interactive = NULL, params = NU
 
   # Knit --------------------------------------------------------------------
 
-  knitr::opts_chunk$set(
-    # NOTE: Usually, Confluence doesn't support syntax highlighting for R, which
-    # makes it harder to distinguish the code block and the result block. So,
-    # by default, collapse code and the result. But, if code_folding is enabled,
-    # do not collapse because folded code blocks can be easily distinguished.
-    collapse = !identical(output_options$code_folding, "hide"),
-    comment = "#>"
-  )
-
   rmarkdown::render(
     input = Rmd_file,
     output_format = output_format,

--- a/R/document.R
+++ b/R/document.R
@@ -104,6 +104,15 @@ confluence_document <- function(title = NULL,
     preserve_yaml = FALSE
   )
 
+  knitr::opts_chunk$set(
+    # NOTE: Usually, Confluence doesn't support syntax highlighting for R, which
+    # makes it harder to distinguish the code block and the result block. So,
+    # by default, collapse code and the result. But, if code_folding is enabled,
+    # do not collapse because folded code blocks can be easily distinguished.
+    collapse = !identical(confluence_settings$code_folding, "hide"),
+    comment = "#>"
+  )
+
   username <- NULL
 
   format$pre_knit <- function(input_file) {


### PR DESCRIPTION
Currently the options are not set if the user doesn't use addin. This PR fixes the inconsistency by moving the logic into the custom format.