### PR TITLE
Make confl_create_post_from_Rmd() return the result URL

### DIFF
--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -112,7 +112,7 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
     title = title,
     body = html_text
   )
-  results_url <- paste0(result$`_links`$base, result$`_links`$webui)
+  result_url <- paste0(result$`_links`$base, result$`_links`$webui)
 
   progress$set(value = 2, message = "Done!")
   Sys.sleep(2)
@@ -124,12 +124,12 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
   # Even on non-interactive sessions, jump to the URL if knitting is done on RStudio
   if (interactive() ||
     (identical(Sys.getenv("RSTUDIO"), "1") && identical(Sys.getenv("TESTTHAT"), ""))) {
-    browseURL(paste0(result$`_links`$base, result$`_links`$webui))
+    browseURL(result_url)
   } else {
-    message(paste0("Results at: ", results_url))
+    message(paste0("Results at: ", result_url))
   }
 
-  results_url
+  result_url
 }
 
 try_get_existing_page_id <- function(title, space_key) {

--- a/R/addin.R
+++ b/R/addin.R
@@ -58,7 +58,7 @@ confl_create_post_from_Rmd <- function(Rmd_file, interactive = NULL, params = NU
 
   # Knit --------------------------------------------------------------------
 
-  rmarkdown::render(
+  output_file <- rmarkdown::render(
     input = Rmd_file,
     output_format = output_format,
     encoding = "UTF-8",
@@ -68,6 +68,9 @@ confl_create_post_from_Rmd <- function(Rmd_file, interactive = NULL, params = NU
     #   assignInNamespace("cedta.pkgEvalsUserCode", c(data.table:::cedta.pkgEvalsUserCode, "conflr"), "data.table")
     env = globalenv()
   )
+
+  # Read the result URL
+  readLines(paste0(output_file, "_result_url"))
 }
 
 confl_create_post_from_Rmd_addin <- function() {
@@ -92,6 +95,9 @@ confl_upload_interactively <- function(title, html_text, imgs, imgs_realpath,
                                        code_folding = "none",
                                        supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
                                        use_original_size = FALSE) {
+
+  # This will be assigned in Shiny's server function
+  result_url <- NULL
 
   # Shiny UI -----------------------------------------------------------
   ui <- confl_addin_ui(
@@ -152,7 +158,7 @@ confl_upload_interactively <- function(title, html_text, imgs, imgs_realpath,
     shiny::observe({
       shiny::req(done())
 
-      confl_upload(
+      result_url <<- confl_upload(
         title = title,
         html_text = html_text,
         imgs = imgs,
@@ -177,6 +183,8 @@ confl_upload_interactively <- function(title, html_text, imgs, imgs_realpath,
 
   viewer <- shiny::dialogViewer("Preview", width = 1000, height = 800)
   shiny::runGadget(ui, server, viewer = viewer)
+
+  result_url
 }
 
 # if the user doesn't want to store the password as envvar, clear it.

--- a/R/document.R
+++ b/R/document.R
@@ -186,7 +186,7 @@ confluence_document <- function(title = NULL,
       # Remove unused arguments
       confluence_settings$update <- NULL
 
-      exec(
+      result_url <- exec(
         confl_upload_interactively,
         !!!confluence_settings,
         html_text = html_text,
@@ -194,7 +194,7 @@ confluence_document <- function(title = NULL,
         imgs_realpath = imgs_realpath
       )
     } else {
-      exec(
+      result_url <- exec(
         confl_upload,
         !!!confluence_settings,
         html_text = html_text,
@@ -202,6 +202,8 @@ confluence_document <- function(title = NULL,
         imgs_realpath = imgs_realpath
       )
     }
+
+    cat(result_url, file = paste0(output_file, "_result_url"))
 
     output_file
   }


### PR DESCRIPTION
Fix #95

After #77, uploading is done inside the `post_processor` of a custom R Markdown document, which can return only `output_file`. So, it's a bit hard to propagate the information to the caller. Possible choices are

1. environment
2. file

and I chose option 2 since environment might not be very safe with the previous results.

Note that, at the moment the file only contains the URL, but probably we can put the whole response from the Confluence into the file. Let's consider when it's needed.