### PR TITLE
add option to mark page updates as minor edit

### DIFF
--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -16,6 +16,7 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
                          supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
                          update = FALSE,
                          use_original_size = FALSE,
+                         minor_edit = FALSE,
                          session = NULL) {
   # TODO: NULL arguments should be `compact()`ed in confluence_document(),
   # but it's not possible to provide a backward-compatibility for
@@ -110,7 +111,8 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
   result <- confl_update_page(
     id = id,
     title = title,
-    body = html_text
+    body = html_text,
+    minor_edit = minor_edit
   )
   result_url <- paste0(result$`_links`$base, result$`_links`$webui)
 

--- a/R/addin.R
+++ b/R/addin.R
@@ -102,7 +102,8 @@ confl_upload_interactively <- function(title, html_text, imgs, imgs_realpath,
                                        toc = FALSE, toc_depth = 7,
                                        code_folding = "none",
                                        supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
-                                       use_original_size = FALSE) {
+                                       use_original_size = FALSE,
+                                       minor_edit = FALSE) {
 
   # This will be assigned in Shiny's server function
   result_url <- NULL
@@ -119,6 +120,7 @@ confl_upload_interactively <- function(title, html_text, imgs, imgs_realpath,
     toc = toc,
     toc_depth = toc_depth,
     code_folding = code_folding,
+    minor_edit = minor_edit,
     use_original_size = use_original_size
   )
 
@@ -181,6 +183,7 @@ confl_upload_interactively <- function(title, html_text, imgs, imgs_realpath,
         code_folding = if (input$code_folding) "hide" else "none",
         supported_syntax_highlighting = supported_syntax_highlighting,
         use_original_size = input$use_original_size,
+        minor_edit = minor_edit,
         # Already confirmed
         update = TRUE
       )
@@ -237,7 +240,8 @@ confl_addin_ui <- function(title, html_text, imgs, imgs_realpath,
                            space_key = NULL, parent_id = NULL, type = "page",
                            toc = FALSE, toc_depth = 7,
                            code_folding = "none",
-                           use_original_size = FALSE) {
+                           use_original_size = FALSE,
+                           minor_edit = FALSE) {
   # title bar
   title_bar_button <- miniUI::miniTitleBarButton("confirm", "Publish", primary = TRUE)
   title_bar <- miniUI::gadgetTitleBar("Preview", right = title_bar_button)
@@ -253,6 +257,8 @@ confl_addin_ui <- function(title, html_text, imgs, imgs_realpath,
 
   # use the original size or not
   use_original_size_input <- shiny::checkboxInput(inputId = "use_original_size", label = "Use original image sizes", value = use_original_size)
+
+  minor_edit_input <- shiny::checkboxInput(inputId = "minor_edit", label = "Minor edit", value = minor_edit)
 
   # add TOC or not
   toc_input <- shiny::checkboxInput(inputId = "toc", label = "TOC", value = toc)
@@ -281,7 +287,8 @@ confl_addin_ui <- function(title, html_text, imgs, imgs_realpath,
         wrap_with_column(parent_id_input),
         wrap_with_column(
           use_original_size_input,
-          code_folding_input
+          code_folding_input,
+          minor_edit_input
         ),
         wrap_with_column(
           toc_input,

--- a/R/content.R
+++ b/R/content.R
@@ -107,7 +107,8 @@ confl_post_page <- function(type = c("page", "blogpost"),
 #' @export
 confl_update_page <- function(id,
                               title,
-                              body) {
+                              body,
+                              minor_edit = FALSE) {
   id <- as.character(id)
   page_info <- confl_get_page(id, expand = "version")
 
@@ -117,7 +118,8 @@ confl_update_page <- function(id,
       title = title,
       body = list(storage = list(value = body, representation = "storage")),
       version = list(
-        number = page_info$version$number + 1L
+        number = page_info$version$number + 1L,
+        minorEdit = minor_edit
       )
     ),
     encode = "json"

--- a/R/content.R
+++ b/R/content.R
@@ -104,6 +104,8 @@ confl_post_page <- function(type = c("page", "blogpost"),
 }
 
 #' @rdname confl_content
+#' @param minor_edit
+#'   If `TRUE`, will mark the `update` as a minor edit not notifying watchers.
 #' @export
 confl_update_page <- function(id,
                               title,

--- a/R/document.R
+++ b/R/document.R
@@ -32,6 +32,8 @@
 #'   If `TRUE`, use the original image sizes.
 #' @param supported_syntax_highlighting
 #'   A named character vector of supported syntax highlighting other than default (e.g. `c(r = "r")`).
+#' @param minor_edit
+#'   If `TRUE`, will mark the `update` as a minor edit not notifying watchers.
 #'
 #' @return
 #'   `confluence_document()` returns an `rmarkdown_output_format` object.
@@ -58,6 +60,7 @@
 #'       foo: bar
 #'     update: true
 #'     use_original_size: true
+#'     minor_edit: false
 #' ---
 #'
 #' ...
@@ -85,6 +88,7 @@ confluence_document <- function(title = NULL,
                                 supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
                                 update = NULL,
                                 use_original_size = FALSE,
+                                minor_edit = FALSE,
                                 interactive = NULL) {
   if (is.null(interactive)) {
     interactive <- interactive()
@@ -104,7 +108,8 @@ confluence_document <- function(title = NULL,
     code_folding = code_folding,
     supported_syntax_highlighting = supported_syntax_highlighting,
     update = update,
-    use_original_size = use_original_size
+    use_original_size = use_original_size,
+    minor_edit = minor_edit
   )
 
   format <- rmarkdown::md_document(

--- a/man/confl_content.Rd
+++ b/man/confl_content.Rd
@@ -51,6 +51,8 @@ contents, use periods. (e.g. \verb{body.storage,history}).}
 \item{body}{The HTML source of the page.}
 
 \item{ancestors}{The page ID of the parent pages.}
+
+\item{minor_edit}{If \code{TRUE}, will mark the \code{update} as a minor edit not notifying watchers.}
 }
 \value{
 The API response as a list.

--- a/man/confl_content.Rd
+++ b/man/confl_content.Rd
@@ -28,7 +28,7 @@ confl_post_page(
   ancestors = NULL
 )
 
-confl_update_page(id, title, body)
+confl_update_page(id, title, body, minor_edit = FALSE)
 
 confl_delete_page(id)
 }

--- a/man/confluence_document.Rd
+++ b/man/confluence_document.Rd
@@ -18,6 +18,7 @@ confluence_document(
   supported_syntax_highlighting = getOption("conflr_supported_syntax_highlighting"),
   update = NULL,
   use_original_size = FALSE,
+  minor_edit = FALSE,
   interactive = NULL
 )
 }
@@ -50,6 +51,8 @@ params in the YAML front-matter.}
 \item{update}{If \code{TRUE}, overwrite the existing page (if it exists).}
 
 \item{use_original_size}{If \code{TRUE}, use the original image sizes.}
+
+\item{minor_edit}{If \code{TRUE}, will mark the \code{update} as a minor edit not notifying watchers.}
 }
 \value{
 \code{confl_create_post_from_Rmd()} returns the URL of the published page.
@@ -76,6 +79,7 @@ output:
       foo: bar
     update: true
     use_original_size: true
+    minor_edit: false
 ---
 
 ...

--- a/tests/testthat/test-content.R
+++ b/tests/testthat/test-content.R
@@ -65,7 +65,8 @@ test_that("confl_update_page() works", {
       )
     ),
     version = list(
-      number = 12L
+      number = 12L,
+      minorEdit = FALSE
     )
   ))
 })


### PR DESCRIPTION
This adds back the reverted feature from #25 -- as it seems to work really nicely with the page update calls.