### PR TITLE
Propagate minor_edit to attatchment operations

### DIFF
--- a/R/addin-internals.R
+++ b/R/addin-internals.R
@@ -75,9 +75,9 @@ confl_upload <- function(title, space_key, type, parent_id, html_text,
 
     img_id <- imgs_exist_ids[basename(imgs[i])]
     if (is.na(img_id)) {
-      confl_post_attachment(id, imgs_realpath[i])
+      confl_post_attachment(id, imgs_realpath[i], minor_edit = minor_edit)
     } else {
-      confl_update_attachment_data(id, img_id, imgs_realpath[i])
+      confl_update_attachment_data(id, img_id, imgs_realpath[i], minor_edit = minor_edit)
     }
 
     progress$set(value = i / num_imgs)

--- a/R/attachment.R
+++ b/R/attachment.R
@@ -55,10 +55,10 @@ confl_list_attachments <- function(id,
 #' @rdname confl_attachment
 #' @param path Path to a file to upload.
 #' @export
-confl_post_attachment <- function(id, path) {
+confl_post_attachment <- function(id, path, minor_edit = FALSE) {
   id <- as.character(id)
   res <- confl_verb("POST", glue::glue("/content/{id}/child/attachment"),
-    body = list(file = httr::upload_file(path)),
+    body = list(file = httr::upload_file(path), minorEdit = minor_edit),
     httr::add_headers(`X-Atlassian-Token` = "nocheck")
   )
   httr::content(res)
@@ -78,10 +78,10 @@ confl_update_attachment_metadata <- function(id, attachmentId, ...) {
 
 #' @rdname confl_attachment
 #' @export
-confl_update_attachment_data <- function(id, attachmentId, path, ...) {
+confl_update_attachment_data <- function(id, attachmentId, path, ..., minor_edit = FALSE) {
   id <- as.character(id)
   res <- confl_verb("POST", glue::glue("/content/{id}/child/attachment/{attachmentId}/data"),
-    body = list(file = httr::upload_file(path)),
+    body = list(file = httr::upload_file(path), minorEdit = minor_edit),
     httr::add_headers(`X-Atlassian-Token` = "nocheck")
   )
   httr::content(res)

--- a/man/confl_attachment.Rd
+++ b/man/confl_attachment.Rd
@@ -17,11 +17,11 @@ confl_list_attachments(
   expand = NULL
 )
 
-confl_post_attachment(id, path)
+confl_post_attachment(id, path, minor_edit = FALSE)
 
 confl_update_attachment_metadata(id, attachmentId, ...)
 
-confl_update_attachment_data(id, attachmentId, path, ...)
+confl_update_attachment_data(id, attachmentId, path, ..., minor_edit = FALSE)
 }
 \arguments{
 \item{id}{The ID of a page that attachments belong to.}
@@ -38,6 +38,8 @@ confl_update_attachment_data(id, attachmentId, path, ...)
 contents, use periods. (e.g. \verb{body.storage,history}).}
 
 \item{path}{Path to a file to upload.}
+
+\item{minor_edit}{If \code{TRUE}, will mark the \code{update} as a minor edit not notifying watchers.}
 
 \item{attachmentId}{The ID of an attachment.}
 


### PR DESCRIPTION
Followup of #107, which hopefully closes #20  

Add `minor_edit` option to the following functions, and pass it inside `confl_upload()`:

* `confl_post_attachment()`
* `confl_update_attachment()`