### PR TITLE
Support tabset

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
   tags for the following Confluence macros: Table of Contents, Jira
   ticket references, Expand and Excerpt blocks (#111 @daroczig).
 
+* Add an experimental support for tabset (#113).
+
 # conflr 0.1.1
 
 * A maintainance relase to fix errors on CRAN check.

--- a/R/addin.R
+++ b/R/addin.R
@@ -215,12 +215,8 @@ write_utf8 <- function(x, f) {
   # Ensure the text is encoded as UTF-8
   x <- enc2utf8(x)
 
-  withr::with_connection(
-    list(con = file(f, open = "w+", encoding = "native.enc")),
-    {
-      writeLines(x, con = con, useBytes = TRUE)
-    }
-  )
+  con <- withr::local_connection(file(f, open = "w+", encoding = "native.enc"))
+  writeLines(x, con = con, useBytes = TRUE)
 }
 
 extract_image_paths <- function(html_text) {

--- a/R/addin.R
+++ b/R/addin.R
@@ -210,6 +210,19 @@ read_utf8 <- function(x) {
   paste(readLines(x, encoding = "UTF-8"), collapse = "\n")
 }
 
+# c.f. https://kevinushey.github.io/blog/2018/02/21/string-encoding-and-r/
+write_utf8 <- function(x, f) {
+  # Ensure the text is encoded as UTF-8
+  x <- enc2utf8(x)
+
+  withr::with_connection(
+    list(con = file(f, open = "w+", encoding = "native.enc")),
+    {
+      writeLines(x, con = con, useBytes = TRUE)
+    }
+  )
+}
+
 extract_image_paths <- function(html_text) {
   html_doc <- xml2::read_html(html_text)
   img_nodes <- xml2::xml_find_all(html_doc, ".//img")

--- a/R/document.R
+++ b/R/document.R
@@ -144,6 +144,17 @@ confluence_document <- function(title = NULL,
     )
   }
 
+  format$pre_processor <- function(metadata, input_file, ...) {
+    md_text_orig <- read_utf8(input_file)
+    md_text <- wrap_tabsets(md_text_orig)
+
+    if (!identical(md_text, md_text_orig)) {
+      write_utf8(md_text, input_file)
+    }
+
+    NULL
+  }
+
   format$post_processor <- function(front_matter, input_file, output_file, clean, verbose) {
     # For backward-compatibility
     if (has_name(front_matter, "confluence_settings")) {

--- a/R/tabset.R
+++ b/R/tabset.R
@@ -1,0 +1,76 @@
+# Copyright (C) 2019 LINE Corporation
+#
+# conflr is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# conflr is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See <http://www.gnu.org/licenses/> for more details.
+
+# {.tabset} notation will be brown away on conversion to commonmark as it is a Pandoc-only syntax.
+wrap_tabsets <- function(x) {
+  stringi::stri_replace_all_regex(x,
+    "(^#+.*?)\\{[^{}]*.tabset[^{}]*\\}",
+    "`<tabset>`{=html}\n\n$1\n\n`</tabset>`{=html}",
+    multiline = TRUE
+  )
+}
+
+mark_tabsets <- function(html_doc) {
+  tabset_level <- determine_tabset_level(html_doc)
+  if (is.null(tabset_level) || is.na(tabset_level)) {
+    return(NULL)
+  }
+
+  tabset_h_tag_name <- glue("h{tabset_level}")
+  # tabs are the headers of one level lower
+  tab_h_tag_name <- glue("h{tabset_level + 1}")
+
+  h_tags <- xml2::xml_find_all(html_doc, glue("//body//{tabset_h_tag_name}|//body//{tab_h_tag_name}"))
+
+  h_tags_len <- length(h_tags)
+  # If the parent is <tabset>, it's the head of a tabset
+  parent_tag_names <- purrr::map_chr(h_tags, ~ xml2::xml_name(xml2::xml_parent(.)))
+  idx_tabset <- parent_tag_names == "tabset"
+
+  # If the parent is not <tabset> but is the header of the same level, it's not tabset
+  idx_no_tabset <- !idx_tabset & (xml2::xml_name(h_tags) == tabset_h_tag_name)
+
+  idx_tab <- xml2::xml_name(h_tags) == tab_h_tag_name
+
+  tabset_ids <- cumsum(idx_tabset)
+  tabset_pos <- which(idx_tabset)
+  no_tabset_pos <- which(idx_no_tabset)
+
+  # headers before the first tabset headers are not tabs
+  tabset_ids[tabset_ids == 0] <- NA
+
+  # headers after non-tabset header and before the next tabset headers are not tabs
+  for (pos in no_tabset_pos) {
+    end_pos <- tabset_pos[tabset_pos > pos]
+    if (length(end_pos) > 0) {
+      end_pos <- end_pos - 1
+    } else {
+      end_pos <- h_tags_len
+    }
+    tabset_ids[pos:end_pos] <- NA
+  }
+
+  tabset_ids
+}
+
+determine_tabset_level <- function(html_doc) {
+  result <- xml2::xml_find_all(html_doc, "//body//tabset/*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5]")
+  if (length(result) == 0) {
+    return(NULL)
+  }
+
+  h_tag_names <- sort(unique(xml2::xml_name(result)))
+
+  if (length(h_tag_names) > 1) {
+    warn("Multiple level of headers are used for tabset")
+  }
+
+  return(as.integer(substr(h_tag_names[1], 2, 2)))
+}

--- a/R/tabset.R
+++ b/R/tabset.R
@@ -24,7 +24,7 @@ mark_tabsets <- function(html_doc) {
   }
 
   xpath <- c("//body//tabset-start", glue("//body//h{i}", i = 1:9))
-  tags <- xml2::xml_find_all(html_doc,　glue_collapse(xpath, sep = "|"))
+  tags <- xml2::xml_find_all(html_doc, glue_collapse(xpath, sep = "|"))
 
   pos_tabset_start <- which(xml2::xml_name(tags) == "tabset-start")
 

--- a/R/tabset.R
+++ b/R/tabset.R
@@ -50,7 +50,8 @@ mark_tabsets <- function(html_doc) {
       xml2::xml_add_sibling(h_tags[end], xml2::as_xml_document("<tabset-end/>"), where = "before")
     }
 
-    xml2::xml_set_name(h_tags[(start + 1):(end - 1)], "tabset-tab")
+    xml2::xml_set_name(h_tags[(start + 1)], "tabset-tab-first")
+    xml2::xml_set_name(h_tags[(start + 2):(end - 1)], "tabset-tab")
   }
 
   NULL
@@ -69,4 +70,68 @@ determine_tabset_level <- function(html_doc) {
   }
 
   return(as.integer(substr(h_tag_names[1], 2, 2)))
+}
+
+
+replace_tabsets <- function(x) {
+  x <- replace_tabsets_start(x)
+  x <- replace_tabsets_tabs_first(x)
+  x <- replace_tabsets_tabs(x)
+  x <- replace_tabsets_end(x)
+  x
+}
+
+
+replace_tabsets_start <- function(x) {
+  stringi::stri_replace_all_regex(
+    x,
+    "<tabset-start>\\s*(<h\\d>)(.*?)(</h\\d>)\\s*</tabset-start>",
+    '$1$2$3
+<ac:structured-macro ac:name="deck">
+<ac:parameter ac:name="id">$2</ac:parameter>
+<ac:rich-text-body>',
+    multiline = TRUE,
+    dotall = TRUE
+  )
+}
+
+replace_tabsets_tabs_first <- function(x) {
+  stringi::stri_replace_all_regex(
+    x,
+    "<tabset-tab-first>\\s*(.*?)\\s*</tabset-tab-first>",
+    '<ac:structured-macro ac:name="card">
+<ac:parameter ac:name="label">$1</ac:parameter>
+<ac:rich-text-body>',
+    multiline = TRUE,
+    dotall = TRUE
+  )
+}
+
+replace_tabsets_tabs <- function(x) {
+  stringi::stri_replace_all_regex(
+    x,
+    "<tabset-tab-first>\\s*(.*?)\\s*</tabset-tab-first>",
+    '</ac:rich-text-body>
+</ac:structured-macro>
+
+<ac:structured-macro ac:name="card">
+<ac:parameter ac:name="label">$1</ac:parameter>
+<ac:rich-text-body>',
+    multiline = TRUE,
+    dotall = TRUE
+  )
+}
+
+replace_tabsets_end <- function(x) {
+  stringi::stri_replace_all_regex(
+    x,
+    "<tabset-end/>",
+    '</ac:rich-text-body>
+</ac:structured-macro>
+
+</ac:rich-text-body>
+</ac:structured-macro>',
+    multiline = TRUE,
+    dotall = TRUE
+  )
 }

--- a/R/translate.R
+++ b/R/translate.R
@@ -63,6 +63,8 @@ translate_to_confl_macro <- function(html_text,
     xml2::xml_text(node) <- text
   }
 
+  mark_tabsets(html_doc)
+
   # Conflucence doesn't accept <br />, so just remove it.
   xml2::xml_remove(xml2::xml_find_all(html_doc, "//br"))
 

--- a/R/translate.R
+++ b/R/translate.R
@@ -80,6 +80,7 @@ translate_to_confl_macro <- function(html_text,
   html_text <- replace_inline_math(html_text)
   html_text <- replace_math(html_text)
   html_text <- replace_image(html_text, image_size_default = image_size_default)
+  html_text <- replace_tabsets(html_text)
   # unescape texts inside CDATA
   html_text <- restore_cdata(html_text)
 

--- a/R/translate.R
+++ b/R/translate.R
@@ -65,7 +65,7 @@ translate_to_confl_macro <- function(html_text,
 
   mark_tabsets(html_doc)
 
-  # Conflucence doesn't accept <br />, so just remove it.
+  # Confluence doesn't accept <br />, so just remove it.
   xml2::xml_remove(xml2::xml_find_all(html_doc, "//br"))
 
   # convert back to character

--- a/tests/testthat/test-tabset.R
+++ b/tests/testthat/test-tabset.R
@@ -1,7 +1,107 @@
 test_that("wrap_tabsets() works", {
-  expect <- "# h1\n`<tabset>`{=html}\n\n# h2 \n\n`</tabset>`{=html}\ntest"
+  expect <- "# h1\n`<tabset-start>`{=html}\n\n# h2 \n\n`</tabset-start>`{=html}\ntest"
 
   expect_equal(wrap_tabsets("# h1\n# h2 {.tabset}\ntest"), expect)
   expect_equal(wrap_tabsets("# h1\n# h2 { .tabset }\ntest"), expect)
   expect_equal(wrap_tabsets("# h1\n# h2 {.some-class .tabset .other-class}\ntest"), expect)
+})
+
+test_that("translate_to_confl_macro() can handle tabset", {
+  # code chunk
+  html_text1 <- commonmark::markdown_html(
+    "
+<tabset-start>
+
+## t1
+
+</tabset-start>
+
+### t2
+
+content2
+
+### t3
+
+content3
+
+## t4
+
+conent4
+
+"
+  )
+  expect_equal(
+    translate_to_confl_macro(html_text1, supported_syntax_highlighting_default),
+    '<h2>t1</h2>
+<ac:structured-macro ac:name="deck">
+<ac:parameter ac:name="id">t1</ac:parameter>
+<ac:rich-text-body>
+<ac:structured-macro ac:name="card">
+<ac:parameter ac:name="label">t2</ac:parameter>
+<ac:rich-text-body>
+<p>content2</p>
+</ac:rich-text-body>
+</ac:structured-macro>
+
+<ac:structured-macro ac:name="card">
+<ac:parameter ac:name="label">t3</ac:parameter>
+<ac:rich-text-body>
+<p>conent3</p>
+</ac:rich-text-body>
+</ac:structured-macro>
+</ac:rich-text-body>
+</ac:structured-macro>
+')
+
+
+  # code chunk
+  html_text2 <- commonmark::markdown_html(
+    "
+## t0
+
+<tabset-start>
+
+## t1
+
+</tabset-start>
+
+### t2
+
+content2
+
+### t3
+
+content3
+
+## t4
+
+conent4
+
+")
+
+  expect_equal(
+    translate_to_confl_macro(html_text2, supported_syntax_highlighting_default),
+    '<h2>t0</h2>
+<h2>t1</h2>
+<ac:structured-macro ac:name="deck">
+<ac:parameter ac:name="id">t1</ac:parameter>
+<ac:rich-text-body>
+<ac:structured-macro ac:name="card">
+<ac:parameter ac:name="label">t2</ac:parameter>
+<ac:rich-text-body>
+<p>content2</p>
+</ac:rich-text-body>
+</ac:structured-macro>
+
+<ac:structured-macro ac:name="card">
+<ac:parameter ac:name="label">t3</ac:parameter>
+<ac:rich-text-body>
+<p>conent3</p>
+</ac:rich-text-body>
+</ac:structured-macro>
+</ac:rich-text-body>
+</ac:structured-macro>
+
+<h2>t4</h4>
+')
 })

--- a/tests/testthat/test-tabset.R
+++ b/tests/testthat/test-tabset.R
@@ -6,6 +6,164 @@ test_that("wrap_tabsets() works", {
   expect_equal(wrap_tabsets("# h1\n# h2 {.some-class .tabset .other-class}\ntest"), expect)
 })
 
+html_doc <- function(x) {
+  x <- commonmark::markdown_html(x)
+  xml2::read_xml(
+    paste0("<body>", x, "</body>"),
+    options = c("RECOVER", "NOERROR", "NOBLANKS")
+  )
+}
+
+test_that("determine_tabset_level() works", {
+  # return NULL for non-tabset document
+  expect_equal(determine_tabset_level(html_doc("# 1\n## 2")), NULL)
+
+  # code chunk
+  html_doc1 <- html_doc(
+    "
+## t1
+
+<tabset-start/>
+
+### t2
+
+content2
+
+### t3
+
+content3
+
+"
+  )
+  expect_equal(determine_tabset_level(html_doc1), 2)
+
+  # invalid case
+  html_doc2 <- html_doc(
+    "
+## t1
+
+<tabset-start/>
+
+### t2
+
+content2
+
+### t3
+
+content3
+
+### invalid
+
+<tabset-start/>
+
+"
+  )
+  expect_warning(
+    expect_equal(determine_tabset_level(html_doc2), 2)
+  )
+
+  # complex case
+  html_doc3 <- html_doc(
+    "
+## t1
+
+# t2
+
+### t3
+
+<tabset-start/>
+
+#### t4
+
+content4
+"
+  )
+
+  expect_equal(determine_tabset_level(html_doc3), 3)
+})
+
+test_that("mark_tabsets() works", {
+  # Do nothing on the document without tabsets
+  expect_null(mark_tabsets(html_doc("## t1\n##t2")))
+
+  html_doc1 <- html_doc(
+    "
+## t1
+
+<tabset-start/>
+
+### t2
+
+content2
+
+### t3
+
+content3
+
+")
+
+  mark_tabsets(html_doc1)
+
+  expect_equal(
+    as.character(html_doc1),
+    '<?xml version="1.0" encoding="UTF-8"?>
+<body>
+  <h2>t1</h2>
+  <tabset-start/>
+  <tabset-tab-first>t2</tabset-tab-first>
+  <p>content2</p>
+  <tabset-tab>t3</tabset-tab>
+  <p>content3</p>
+  <tabset-end/>
+</body>
+')
+
+  html_doc2 <- html_doc(
+    "
+## t1
+
+<tabset-start/>
+
+### t2
+
+content2
+
+## t3
+
+<tabset-start/>
+
+### t4
+
+content4
+
+### t5
+
+## t1
+
+")
+
+  mark_tabsets(html_doc2)
+
+  expect_equal(
+    as.character(html_doc2),
+    '<?xml version="1.0" encoding="UTF-8"?>
+<body>
+  <h2>t1</h2>
+  <tabset-start/>
+  <tabset-tab-first>t2</tabset-tab-first>
+  <p>content2</p>
+  <tabset-end/>
+  <h2>t3</h2>
+  <tabset-start/>
+  <tabset-tab-first>t4</tabset-tab-first>
+  <p>content4</p>
+  <tabset-tab>t5</tabset-tab>
+  <tabset-end/>
+  <h2>t1</h2>
+</body>
+')
+})
+
 test_that("translate_to_confl_macro() can handle tabset", {
   # code chunk
   html_text1 <- commonmark::markdown_html(

--- a/tests/testthat/test-tabset.R
+++ b/tests/testthat/test-tabset.R
@@ -14,74 +14,6 @@ html_doc <- function(x) {
   )
 }
 
-test_that("determine_tabset_level() works", {
-  # return NULL for non-tabset document
-  expect_equal(determine_tabset_level(html_doc("# 1\n## 2")), NULL)
-
-  # code chunk
-  html_doc1 <- html_doc(
-    "
-## t1
-
-<tabset-start/>
-
-### t2
-
-content2
-
-### t3
-
-content3
-
-"
-  )
-  expect_equal(determine_tabset_level(html_doc1), 2)
-
-  # invalid case
-  html_doc2 <- html_doc(
-    "
-## t1
-
-<tabset-start/>
-
-### t2
-
-content2
-
-### t3
-
-content3
-
-### invalid
-
-<tabset-start/>
-
-"
-  )
-  expect_warning(
-    expect_equal(determine_tabset_level(html_doc2), 2)
-  )
-
-  # complex case
-  html_doc3 <- html_doc(
-    "
-## t1
-
-# t2
-
-### t3
-
-<tabset-start/>
-
-#### t4
-
-content4
-"
-  )
-
-  expect_equal(determine_tabset_level(html_doc3), 3)
-})
-
 test_that("mark_tabsets() works", {
   # Do nothing on the document without tabsets
   expect_null(mark_tabsets(html_doc("## t1\n##t2")))
@@ -128,17 +60,17 @@ content3
 
 content2
 
-## t3
+# t3
 
 <tabset-start/>
 
-### t4
+## t4
 
 content4
 
-### t5
+## t5
 
-## t1
+# t1
 
 ")
 
@@ -153,13 +85,57 @@ content4
   <tabset-tab-first>t2</tabset-tab-first>
   <p>content2</p>
   <tabset-end/>
-  <h2>t3</h2>
+  <h1>t3</h1>
   <tabset-start/>
   <tabset-tab-first>t4</tabset-tab-first>
   <p>content4</p>
   <tabset-tab>t5</tabset-tab>
   <tabset-end/>
+  <h1>t1</h1>
+</body>
+')
+
+  # second <tabset-start/> should be ignored
+  html_doc3 <- html_doc(
+    "
+## t1
+
+<tabset-start/>
+
+### t2
+
+content2
+
+### t3
+
+<tabset-start/>
+
+### t4
+
+content4
+
+### t5
+
+# t1
+
+")
+
+  mark_tabsets(html_doc3)
+
+  expect_equal(
+    as.character(html_doc3),
+    '<?xml version="1.0" encoding="UTF-8"?>
+<body>
   <h2>t1</h2>
+  <tabset-start/>
+  <tabset-tab-first>t2</tabset-tab-first>
+  <p>content2</p>
+  <tabset-tab>t3</tabset-tab>
+  <tabset-tab>t4</tabset-tab>
+  <p>content4</p>
+  <tabset-tab>t5</tabset-tab>
+  <tabset-end/>
+  <h1>t1</h1>
 </body>
 ')
 })

--- a/tests/testthat/test-tabset.R
+++ b/tests/testthat/test-tabset.R
@@ -24,10 +24,6 @@ content2
 
 content3
 
-## t4
-
-conent4
-
 "
   )
   expect_equal(
@@ -46,12 +42,12 @@ conent4
 <ac:structured-macro ac:name="card">
 <ac:parameter ac:name="label">t3</ac:parameter>
 <ac:rich-text-body>
-<p>conent3</p>
+<p>content3</p>
 </ac:rich-text-body>
 </ac:structured-macro>
+
 </ac:rich-text-body>
-</ac:structured-macro>
-')
+</ac:structured-macro>')
 
 
   # code chunk
@@ -96,12 +92,12 @@ conent4
 <ac:structured-macro ac:name="card">
 <ac:parameter ac:name="label">t3</ac:parameter>
 <ac:rich-text-body>
-<p>conent3</p>
-</ac:rich-text-body>
-</ac:structured-macro>
+<p>content3</p>
 </ac:rich-text-body>
 </ac:structured-macro>
 
-<h2>t4</h4>
-')
+</ac:rich-text-body>
+</ac:structured-macro>
+<h2>t4</h2>
+<p>conent4</p>')
 })

--- a/tests/testthat/test-tabset.R
+++ b/tests/testthat/test-tabset.R
@@ -1,0 +1,7 @@
+test_that("wrap_tabsets() works", {
+  expect <- "# h1\n`<tabset>`{=html}\n\n# h2 \n\n`</tabset>`{=html}\ntest"
+
+  expect_equal(wrap_tabsets("# h1\n# h2 {.tabset}\ntest"), expect)
+  expect_equal(wrap_tabsets("# h1\n# h2 { .tabset }\ntest"), expect)
+  expect_equal(wrap_tabsets("# h1\n# h2 {.some-class .tabset .other-class}\ntest"), expect)
+})

--- a/tests/testthat/test-tabset.R
+++ b/tests/testthat/test-tabset.R
@@ -1,5 +1,5 @@
 test_that("wrap_tabsets() works", {
-  expect <- "# h1\n`<tabset-start>`{=html}\n\n# h2 \n\n`</tabset-start>`{=html}\ntest"
+  expect <- "# h1\n# h2 \n\n`<tabset-start/>`{=html}\ntest"
 
   expect_equal(wrap_tabsets("# h1\n# h2 {.tabset}\ntest"), expect)
   expect_equal(wrap_tabsets("# h1\n# h2 { .tabset }\ntest"), expect)
@@ -10,11 +10,9 @@ test_that("translate_to_confl_macro() can handle tabset", {
   # code chunk
   html_text1 <- commonmark::markdown_html(
     "
-<tabset-start>
-
 ## t1
 
-</tabset-start>
+<tabset-start/>
 
 ### t2
 
@@ -55,11 +53,9 @@ content3
     "
 ## t0
 
-<tabset-start>
-
 ## t1
 
-</tabset-start>
+<tabset-start/>
 
 ### t2
 


### PR DESCRIPTION
Close #82 

rmarkdown package implements tabset feature mostly on JavaScript's side, so imitating it on Confluence is a very tough job.

### Bypass commonmark

`{.tabset}` notation is only available on Pandoc markdown and will be blown away when it gets converted to commonmark. So, we need to tweak it before executing `pandoc`. This should be done in `pre_processor()`. This PR replaces `{.tabset}` with `<tabset-start/>` tags so that we can handle this as an XML a bit easier on the next step.

Keep in mind that this risks to mess the text files because of the encoding problems. If there's no tabsets, we shouldn't do anything.


### Parse the result as XML and mark the locations of tabsets

This is done in `translate_to_confl_macro()` as usual. We need to see the order of header tags to determine the end of the tabset section. Take a look at some examples. 

In this example, there is one tabset that contains `t1` as a header and `t2` and `t3` as tabs. This can be determined by the fact that `t4` is a header of the same level (`h2`) of the start of the tabset. This means we need to check `h*` headers sequentially.

``` md
## t1 {.tabset}

### t2

### t3

## t4

```

One more example. In this case, there is one tabset `t1` that contains two tabs; `t2`, which contains `t3`, and `t4`, which is NOT a tabset header as it is `h4`.  The header level of tabs is one step lower than that of the tabset header. So, we need to determine the header first to determine the header level of tabs. 

``` md
### t1 {.tabset}

#### t2

##### t3

#### t4 {.tabset}

```

How many types of marks do we need? Let's see the next section.

### Replace the marks with the actual `<ac:..>` tags

We need to know

1. the start of the tabset
2. first tab
3. the other tabs
4. the end of the tabset

Why do we need to distinguish 2. and 3.? Since it's easy to do a regex-fu as shown below:

``` 
                +-(1)--------------------------------------------
## t1 {.tabset} | <h2>t1</h2>
                | 
                | <ac:structured-macro ac:name="deck">
                |   <ac:parameter ac:name="id">t1</ac:parameter>
                |   <ac:rich-text-body>
                |
                +-(2)--------------------------------------------
### t2          |     <ac:structured-macro ac:name="card">
                |       <ac:parameter ac:name="label">t2</ac:parameter>
aaa             |       <ac:rich-text-body>
                |         <p>aaa</p>
                |
                +-(3)--------------------------------------------
                |       </ac:rich-text-body>
                |     </ac:structured-macro>
                | 
### t3          |     <ac:structured-macro ac:name="card">
                |       <ac:parameter ac:name="label">t3</ac:parameter>
bbb             |       <ac:rich-text-body>
                |         <p>bbb</p>
                |
                +-(4)--------------------------------------------
                |       </ac:rich-text-body>
                |     </ac:structured-macro>
                |
                |   </ac:rich-text-body>
                | </ac:structured-macro>
                |
                |
                +------------------------------------------------
## t4           | 
                | 
                | 
                | 
```
