### PR TITLE
add whitespace

### DIFF
--- a/R/macros.R
+++ b/R/macros.R
@@ -17,14 +17,14 @@
 #' @keywords internal
 conf_macro_generator <- function(type = c('inline', 'block'),
                                  name, parameters = NULL, body = NULL) {
+
   type <- match.arg(type)
 
-  macro <- switch(
-    type,
-    inline = '`',
-    block = '\n```{=html}\n')
+  open <- switch(type, inline = '`', block = '```{=html}')
+  close <- switch(type, inline = '`{=html}', block = '\n```\n')
+  spacer <- switch(type, inline = '', block = '\n')
 
-  macro <- glue('{macro}<ac:structured-macro ac:name="{name}">')
+  macro <- glue('{open}<ac:structured-macro ac:name="{name}">{spacer}')
 
   if (!is.null(parameters)) {
     for (parameter in names(parameters)) {
@@ -32,23 +32,21 @@ conf_macro_generator <- function(type = c('inline', 'block'),
         macro,
         glue('<ac:parameter ac:name="{parameter}">'),
         parameters[[parameter]],
-        '</ac:parameter>')
+        '</ac:parameter>{spacer}')
     }
   }
 
   if (!is.null(body)) {
     macro <- paste0(
       macro,
-      '<ac:rich-text-body>',
+      '<ac:rich-text-body><![CDATA[',
       body,
-      '</ac:rich-text-body>')
+      ']]></ac:rich-text-body>',
+      spacer)
   }
 
   macro <- paste0(macro, '</ac:structured-macro>')
-  macro <- paste0(macro, switch(
-    type,
-    inline = '`{=html}',
-    block = '\n```\n'))
+  macro <- paste0(macro, close)
 
   macro
 

--- a/R/macros.R
+++ b/R/macros.R
@@ -20,7 +20,7 @@ conf_macro_generator <- function(type = c('inline', 'block'),
 
   type <- match.arg(type)
 
-  open <- switch(type, inline = '`', block = '```{=html}')
+  open <- switch(type, inline = '`', block = '\n```{=html}\n')
   close <- switch(type, inline = '`{=html}', block = '\n```\n')
   spacer <- switch(type, inline = '', block = '\n')
 
@@ -39,9 +39,9 @@ conf_macro_generator <- function(type = c('inline', 'block'),
   if (!is.null(body)) {
     macro <- paste0(
       macro,
-      '<ac:rich-text-body><![CDATA[',
-      body,
-      ']]></ac:rich-text-body>',
+      '<ac:rich-text-body>',
+      spacer, body, spacer,
+      '</ac:rich-text-body>',
       spacer)
   }
 


### PR DESCRIPTION
I hit some strange XML read parsing errors ... that I was not able to trace back properly, but spending a couple hours (duh) on this, it seems that separating the `ac` tags on their own line fixes the issue :thinking: 

I suspected it might be due to some regular expression tweaks that is now not causing the issues due to the split lines, but I was not able to debug any further.

Anyway, this fixes the issues with the complex macro blocks ... so I thought it would make sense to contribute back to the main repo, and you might also know better why this extra whitespace is needed :shrug: 