### PR TITLE
small typo in readme

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -116,7 +116,7 @@ conflr to overwrite the existing page.
 confl_create_post_from_Rmd("~/path/to/your.Rmd", interactive = FALSE, update = TRUE)
 ```
 
-### `conflr::conflence_document`
+### `conflr::confluence_document`
 
 conflr's functionality is also available as a custom R Markdown format;
 You can specify `conflr::confluence_document` to `output` in the front matter of your R Markdown document.


### PR DESCRIPTION
Hi, I noticed a small typo in the readme, `conflr::confluence_document` was misspelled. I only modified the R Markdown file, the knitted .md file still needs to be rendered.